### PR TITLE
Add web-compatible document actions and desktop IPC wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Task Completion Requirements
 
 - Run `pnpm format`, `pnpm lint`, and `pnpm type-check` before considering a task complete.
+- Before running a script command that uses `vite preview`, don't forget to build the app first.
 - If tests are relevant to the change, run the smallest targeted suite first, then expand only if needed. Prefer `pnpm test:unit`, `pnpm test:e2e:dev`, or `pnpm test:e2e` over ad hoc commands.
 - Do not use outdated or redundant scripts when a repo-specific command already exists.
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,22 @@ Markdown Studio is a split-pane Markdown editor that lets you write on one side 
 ### For Writers
 
 - **Split-pane editor** — Write on the left, preview on the right
+- **View modes** — Toggle between split view, editor-only, or preview-only modes
 - **Live Markdown rendering** — See changes instantly as you type
 - **Mermaid diagram support** — Create flowcharts, sequence diagrams, ER diagrams, and Gantt charts using simple text syntax
-- **Theme switching** — Toggle between light and dark modes
-- **Word and character count** — Track your document stats in real-time
+- **Theme switching** — Toggle between light and dark modes with smooth animated transitions
+- **Document statistics** — Track word, character, line, and diagram counts in real-time
 - **Example documents** — Load pre-made templates to learn Markdown or Mermaid syntax
-- **Copy to clipboard** — Quickly copy your Markdown source
+- **Copy to clipboard** — Quickly copy your Markdown source with visual feedback
 
 ### For Developers
 
 - **Safe HTML rendering** — Content is sanitized with DOMPurify
-- **File operations** — Open, save, and manage `.md` files (desktop app)
+- **File System Access API** — Open and save files directly in supported browsers
+- **Desktop file operations** — Full file management in the Electron app
 - **Responsive design** — Works on desktop and mobile devices
 - **Keyboard shortcuts** — Efficient editing with familiar shortcuts
+- **Scroll synchronization** — Source map tracking enables editor-preview sync
 
 ## Getting Started
 
@@ -83,6 +86,16 @@ pnpm dist:mac
 
 Simply start typing in the editor pane. The preview pane updates automatically as you write.
 
+### Switching View Modes
+
+Click the view toggle buttons to switch between:
+
+- **Editor** — Write without distractions
+- **Split** — Side-by-side editing and preview (default)
+- **Preview** — Focus on the rendered output
+
+The editor automatically adapts to your preferred layout.
+
 ### Creating Diagrams
 
 Use Mermaid syntax within fenced code blocks:
@@ -106,20 +119,34 @@ Supported diagram types include:
 
 ### Switching Themes
 
-Click the theme toggle button in the toolbar to switch between light and dark modes. The transition includes a smooth animation effect.
+Click the theme toggle button in the toolbar to switch between light and dark modes. The transition includes a smooth circular reveal animation that emanates from the toggle button.
 
 ### Loading Examples
 
-Click the "Examples" button in the toolbar to browse and load pre-made documents demonstrating various Markdown and Mermaid features.
+Click the "Examples" button in the toolbar to browse and load pre-made templates. Choose from:
 
-### File Operations (Desktop)
+- **Flowchart diagram** — Git feature branch workflow
+- **Sequence diagram** — JWT authentication flow
+- **Entity relationship diagram** — Blog platform database schema
+- **Gantt chart** — Product launch timeline
+- **Full kitchen-sink** — Complete Markdown feature demonstration
 
-When running the desktop app:
+The kitchen-sink example loads by default on first visit.
 
-- **Open** — Load existing `.md` files
+### File Operations
+
+**Desktop App:**
+
+- **Open** — Load existing `.md` files via native dialogs
 - **Save** — Save your current document
 - **Save As** — Save with a new name or location
-- **New Document** — Start fresh with an empty editor
+- **Clear** — Start fresh with an empty editor
+
+**Web App:**
+
+- **Open** — Load `.md` files using the File System Access API (Chrome/Edge) or file picker
+- **Save** — Save to previously opened file, or download if using the fallback
+- **Save As** — Save with a new name (uses File System Access API when available, otherwise downloads)
 
 ## Development
 
@@ -129,15 +156,22 @@ When running the desktop app:
 src/
 ├── features/markdown/
 │   ├── components/        # UI components (EditorPane, PreviewPane, Toolbar, etc.)
-│   └── composables/       # Business logic (useMarkdownEditor, useDocumentSession)
-├── composables/           # Shared composables (useTheme, useDesktop)
-├── utils/                 # Utility functions
+│   ├── composables/       # Business logic (useMarkdownEditor, useDocumentSession, useDocumentActions)
+│   └── types/             # TypeScript types for the markdown feature
+├── components/            # Shared UI components (ThemeToggle, ViewToggle, Modal, ToolbarButton)
+├── composables/           # Shared composables (useTheme, useThemeTransition, useDesktop)
+├── utils/                 # Utility functions (escapeHtml, platform detection)
 ├── views/                 # Page-level components
 ├── router/                # Vue Router configuration
-├── App.vue               # Root component
-└── main.ts               # Application entry point
+├── App.vue                # Root component
+└── main.ts                # Application entry point
 
 electron/                  # Electron main process code
+├── ipc/                   # IPC handlers for documents and shell
+├── menu/                  # Application menu configuration
+├── shared/                # Shared types and validation
+├── main.ts                # Electron entry point
+└── preload.ts             # Preload script for secure IPC
 ```
 
 ### Tech Stack
@@ -145,7 +179,6 @@ electron/                  # Electron main process code
 - **Vue 3** — Progressive JavaScript framework with Composition API
 - **Vite** — Fast build tool and dev server
 - **TypeScript** — Type-safe development
-- **Pinia** — State management
 - **Vue Router** — Client-side routing
 - **Marked** — Markdown parser and compiler
 - **DOMPurify** — HTML sanitization
@@ -153,6 +186,10 @@ electron/                  # Electron main process code
 - **Electron** — Cross-platform desktop app framework
 - **electron-vite** — Vite integration for Electron
 - **electron-builder** — Packaging and distribution
+- **Vitest** — Unit testing framework
+- **Cypress** — End-to-end testing
+- **ESLint + oxlint** — Linting and code quality
+- **oxfmt** — Code formatting
 
 ### Available Scripts
 
@@ -194,10 +231,11 @@ The workflow currently packages the macOS desktop app, uploads the generated `.d
 
 ### Architecture Highlights
 
-- **Composables-based architecture** — Logic is organized into reusable Vue composables
-- **Feature-based folder structure** — Related components and logic live together
-- **Desktop/web abstraction** — Clean separation between web and Electron APIs
-- **Source map tracking** — Enables sync between editor scroll position and preview
+- **Composables-based architecture** — Logic is organized into reusable Vue composables (useTheme, useMarkdownEditor, useDocumentActions, useDocumentSession)
+- **Feature-based folder structure** — Related components and logic live together in `src/features/`
+- **Desktop/web abstraction** — Clean separation between web and Electron APIs via useDesktop composable
+- **Source map tracking** — Line-level mapping enables scroll synchronization between editor and preview
+- **Theme transition system** — Smooth animated theme switches with useThemeTransition
 
 ## Browser Support
 

--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -1,8 +1,73 @@
+function stubBrowserDownload(win: Window, downloads: { href: string; name: string }[]): void {
+  const originalCreateElement = win.document.createElement.bind(win.document)
+
+  win.URL.createObjectURL = () => 'blob:markdown-studio'
+  win.URL.revokeObjectURL = () => undefined
+  win.showSaveFilePicker = undefined
+
+  win.document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
+    const element = originalCreateElement(tagName, options)
+
+    if (tagName.toLowerCase() === 'a') {
+      const anchor = element as HTMLAnchorElement
+      anchor.click = () => {
+        downloads.push({
+          href: anchor.href,
+          name: anchor.download,
+        })
+      }
+    }
+
+    return element
+  }) as typeof win.document.createElement
+}
+
+function stubBrowserOpen(win: Window, fileName: string, content: string): void {
+  const originalCreateElement = win.document.createElement.bind(win.document)
+
+  win.document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
+    const element = originalCreateElement(tagName, options)
+
+    if (tagName.toLowerCase() === 'input') {
+      const input = element as HTMLInputElement
+      input.click = () => {
+        const file = new win.File([content], fileName, { type: 'text/markdown' })
+
+        Object.defineProperty(input, 'files', {
+          configurable: true,
+          value: [file],
+        })
+
+        input.dispatchEvent(new win.Event('change'))
+      }
+    }
+
+    return element
+  }) as typeof win.document.createElement
+}
+
+function stubBrowserSavePicker(win: Window, writes: string[], fileName: string): void {
+  win.showSaveFilePicker = async () =>
+    ({
+      createWritable: async () =>
+        ({
+          close: async () => undefined,
+          write: async (value: string) => {
+            writes.push(value)
+          },
+        }) as unknown as FileSystemWritableFileStream,
+      kind: 'file',
+      name: fileName,
+    }) as FileSystemFileHandle
+}
+
 describe('Markdown Studio responsive shell', () => {
   it('keeps the primary mobile controls visible and usable', () => {
     cy.viewport('iphone-6')
     cy.visit('/')
 
+    cy.get('.toolbar__actions').contains('button', 'Open').should('be.visible')
+    cy.get('.toolbar__actions').contains('button', 'Save').should('be.visible')
     cy.get('.toolbar__mobile-controls').contains('button', 'Preview').click()
     cy.get('.preview-pane').should('be.visible')
     cy.get('.editor-pane').should('not.be.visible')
@@ -31,6 +96,8 @@ describe('Markdown Studio responsive shell', () => {
   it('keeps split view on desktop and hides it on mobile', () => {
     cy.viewport(1280, 900)
     cy.visit('/')
+    cy.get('.toolbar__actions').contains('button', 'Open').should('be.visible')
+    cy.get('.toolbar__actions').contains('button', 'Save').should('be.visible')
     cy.get('.toolbar__desktop-controls').contains('button', 'Split').should('be.visible')
     cy.get('.editor-pane').should('be.visible')
     cy.get('.preview-pane').should('be.visible')
@@ -40,6 +107,71 @@ describe('Markdown Studio responsive shell', () => {
     cy.contains('button', 'Split').should('not.exist')
     cy.get('.toolbar__mobile-controls').contains('button', 'Editor').should('be.visible')
     cy.get('.toolbar__mobile-controls').contains('button', 'Preview').should('be.visible')
+  })
+
+  it('opens a markdown file from the web toolbar', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        stubBrowserOpen(win, 'web-notes.md', '# Imported from Cypress')
+      },
+    })
+
+    cy.get('.toolbar__actions').contains('button', 'Open').click()
+
+    cy.get('textarea').should('have.value', '# Imported from Cypress')
+    cy.get('.status-item--document').should('contain', 'web-notes.md')
+    cy.get('.status-bar').should('contain', 'Opened web-notes.md')
+  })
+
+  it('downloads markdown from the web toolbar when no persistent file handle exists', () => {
+    cy.viewport(1280, 900)
+    const downloads: { href: string; name: string }[] = []
+
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        stubBrowserDownload(win, downloads)
+      },
+    })
+
+    cy.get('textarea').clear()
+    cy.get('textarea').type('# Downloaded from web')
+    cy.get('.toolbar__actions').contains('button', 'Save').click()
+
+    cy.wrap(null).then(() => {
+      expect(downloads).to.have.length(1)
+      expect(downloads[0]).to.deep.equal({
+        href: 'blob:markdown-studio',
+        name: 'Untitled.md',
+      })
+    })
+    cy.get('.status-item--document').should('contain', 'Untitled.md')
+    cy.get('.status-bar').should('contain', 'Saved Untitled.md')
+  })
+
+  it('reuses the browser save handle after the first save', () => {
+    cy.viewport(1280, 900)
+    const writes: string[] = []
+
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        stubBrowserSavePicker(win, writes, 'picked-from-browser.md')
+      },
+    })
+
+    cy.get('textarea').clear()
+    cy.get('textarea').type('# First save')
+    cy.get('.toolbar__actions').contains('button', 'Save').click()
+    cy.get('.status-item--document').should('contain', 'picked-from-browser.md')
+
+    cy.get('textarea').clear()
+    cy.get('textarea').type('# Second save')
+    cy.get('.toolbar__actions').contains('button', 'Save').click()
+
+    cy.wrap(null).then(() => {
+      expect(writes).to.deep.equal(['# First save', '# Second save'])
+    })
+    cy.get('.status-bar').should('contain', 'Saved picked-from-browser.md')
   })
 
   it('syncs preview scrolling with the editor in split mode', () => {

--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -1,4 +1,9 @@
-function stubBrowserDownload(win: Window, downloads: { href: string; name: string }[]): void {
+type BrowserWindow = typeof globalThis & Window
+
+function stubBrowserDownload(
+  win: BrowserWindow,
+  downloads: { href: string; name: string }[],
+): void {
   const originalCreateElement = win.document.createElement.bind(win.document)
 
   win.URL.createObjectURL = () => 'blob:markdown-studio'
@@ -22,31 +27,18 @@ function stubBrowserDownload(win: Window, downloads: { href: string; name: strin
   }) as typeof win.document.createElement
 }
 
-function stubBrowserOpen(win: Window, fileName: string, content: string): void {
-  const originalCreateElement = win.document.createElement.bind(win.document)
-
-  win.document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
-    const element = originalCreateElement(tagName, options)
-
-    if (tagName.toLowerCase() === 'input') {
-      const input = element as HTMLInputElement
-      input.click = () => {
-        const file = new win.File([content], fileName, { type: 'text/markdown' })
-
-        Object.defineProperty(input, 'files', {
-          configurable: true,
-          value: [file],
-        })
-
-        input.dispatchEvent(new win.Event('change'))
-      }
-    }
-
-    return element
-  }) as typeof win.document.createElement
+function stubBrowserOpen(win: BrowserWindow, fileName: string, content: string): void {
+  win.showOpenFilePicker = async () =>
+    [
+      {
+        getFile: async () => new win.File([content], fileName, { type: 'text/markdown' }),
+        kind: 'file',
+        name: fileName,
+      } as FileSystemFileHandle,
+    ] satisfies FileSystemFileHandle[]
 }
 
-function stubBrowserSavePicker(win: Window, writes: string[], fileName: string): void {
+function stubBrowserSavePicker(win: BrowserWindow, writes: string[], fileName: string): void {
   win.showSaveFilePicker = async () =>
     ({
       createWritable: async () =>

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["./e2e/**/*", "./support/**/*"],
+  "include": ["../env.d.ts", "./e2e/**/*", "./support/**/*"],
   "exclude": ["./support/component.*"],
   "compilerOptions": {
     "isolatedModules": false,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@electron': fileURLToPath(new URL('./electron', import.meta.url)),
       },
     },
   },
@@ -43,6 +44,12 @@ export default defineConfig({
         },
       },
     },
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@electron': fileURLToPath(new URL('./electron', import.meta.url)),
+      },
+    },
   },
   renderer: {
     build: {
@@ -54,6 +61,7 @@ export default defineConfig({
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@electron': fileURLToPath(new URL('./electron', import.meta.url)),
       },
     },
     root: '.',

--- a/electron/__tests__/validation.spec.ts
+++ b/electron/__tests__/validation.spec.ts
@@ -1,13 +1,12 @@
 // @vitest-environment node
 
-import { describe, expect, it } from 'vitest'
-
 import {
   assertExternalUrl,
   assertSaveAsInput,
   assertSaveInput,
   getDefaultMarkdownPath,
-} from '../shared/validation'
+} from '@electron/shared/validation'
+import { describe, expect, it } from 'vitest'
 
 describe('desktop validation', () => {
   it('normalizes valid save input', () => {

--- a/electron/ipc/documents.ts
+++ b/electron/ipc/documents.ts
@@ -1,20 +1,23 @@
-import { type BrowserWindow, dialog, ipcMain } from 'electron'
-import { readFile, writeFile } from 'node:fs/promises'
-
-import type { DesktopDocumentHandle, DesktopSaveAsInput, DesktopSaveInput } from '../shared/types'
+import type {
+  DesktopDocumentHandle,
+  DesktopSaveAsInput,
+  DesktopSaveInput,
+} from '@electron/shared/types'
 
 import {
   DOCUMENTS_OPEN_CHANNEL,
   DOCUMENTS_SAVE_AS_CHANNEL,
   DOCUMENTS_SAVE_CHANNEL,
   SHELL_OPEN_EXTERNAL_CHANNEL,
-} from '../shared/channels'
+} from '@electron/shared/channels'
 import {
   assertExternalUrl,
   assertSaveAsInput,
   assertSaveInput,
   getDefaultMarkdownPath,
-} from '../shared/validation'
+} from '@electron/shared/validation'
+import { type BrowserWindow, dialog, ipcMain } from 'electron'
+import { readFile, writeFile } from 'node:fs/promises'
 
 const MARKDOWN_FILTERS = [
   { extensions: ['md', 'markdown', 'mdown'], name: 'Markdown Files' },

--- a/electron/menu/appMenu.ts
+++ b/electron/menu/appMenu.ts
@@ -1,8 +1,7 @@
+import type { AppCommand } from '@electron/shared/types'
+
+import { APP_COMMAND_CHANNEL } from '@electron/shared/channels'
 import { type BrowserWindow, Menu, type MenuItemConstructorOptions } from 'electron'
-
-import type { AppCommand } from '../shared/types'
-
-import { APP_COMMAND_CHANNEL } from '../shared/channels'
 
 export function buildAppMenu(mainWindow: BrowserWindow): Menu {
   const template: MenuItemConstructorOptions[] = [

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
-
-import type { DesktopApi } from './shared/types'
+import type { DesktopApi } from '@electron/shared/types'
 
 import {
   APP_COMMAND_CHANNEL,
@@ -8,7 +6,8 @@ import {
   DOCUMENTS_SAVE_AS_CHANNEL,
   DOCUMENTS_SAVE_CHANNEL,
   SHELL_OPEN_EXTERNAL_CHANNEL,
-} from './shared/channels'
+} from '@electron/shared/channels'
+import { contextBridge, ipcRenderer } from 'electron'
 
 function createDesktopApi(): DesktopApi {
   return {

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,10 +1,56 @@
 /// <reference types="vite/client" />
 
-import type { DesktopApi } from './electron/shared/types'
+import type { DesktopApi } from '@electron/shared/types'
 
 declare global {
+  interface FilePickerAcceptType {
+    accept?: Record<string, string[]>
+    description?: string
+  }
+
+  interface FilePickerOptions {
+    excludeAcceptAllOption?: boolean
+    id?: string
+    startIn?: string
+    suggestedName?: string
+    types?: FilePickerAcceptType[]
+  }
+
+  interface FileSystemFileHandle {
+    createWritable: () => Promise<FileSystemWritableFileStream>
+    getFile: () => Promise<File>
+    kind: 'file'
+    name: string
+  }
+
+  interface FileSystemWritableFileStream extends WritableStream {
+    close(): Promise<void>
+    write(
+      data:
+        | {
+            data: ArrayBuffer | ArrayBufferView | Blob | DataView | string
+            position?: number
+            type: 'write'
+          }
+        | {
+            position: number
+            type: 'seek'
+          }
+        | {
+            size: number
+            type: 'truncate'
+          }
+        | ArrayBuffer
+        | ArrayBufferView
+        | Blob
+        | DataView
+        | string,
+    ): Promise<void>
+  }
+
   interface Window {
     desktop?: DesktopApi
+    showSaveFilePicker?: (options?: FilePickerOptions) => Promise<FileSystemFileHandle>
   }
 }
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -11,6 +11,7 @@ declare global {
   interface FilePickerOptions {
     excludeAcceptAllOption?: boolean
     id?: string
+    multiple?: boolean
     startIn?: string
     suggestedName?: string
     types?: FilePickerAcceptType[]
@@ -50,6 +51,7 @@ declare global {
 
   interface Window {
     desktop?: DesktopApi
+    showOpenFilePicker?: (options?: FilePickerOptions) => Promise<FileSystemFileHandle[]>
     showSaveFilePicker?: (options?: FilePickerOptions) => Promise<FileSystemFileHandle>
   }
 }

--- a/src/composables/useDesktop.ts
+++ b/src/composables/useDesktop.ts
@@ -1,6 +1,6 @@
-import { computed } from 'vue'
+import type { DesktopApi } from '@electron/shared/types'
 
-import type { DesktopApi } from '../../electron/shared/types'
+import { computed } from 'vue'
 
 const fallbackDesktopApi: DesktopApi = {
   commands: {

--- a/src/features/markdown/components/Toolbar.vue
+++ b/src/features/markdown/components/Toolbar.vue
@@ -7,8 +7,9 @@ import type { Theme, ViewMode } from '../types'
 
 interface Props {
   availableModes?: ViewMode[]
+  canOpenDocuments?: boolean
+  canSaveDocuments?: boolean
   isCopied: boolean
-  isDesktop?: boolean
   isMobile?: boolean
   theme: Theme
   viewMode: ViewMode
@@ -21,6 +22,8 @@ interface ThemeChangeRequest {
 
 const props = withDefaults(defineProps<Props>(), {
   availableModes: () => ['editor', 'split', 'preview'],
+  canOpenDocuments: false,
+  canSaveDocuments: false,
   isMobile: false,
 })
 
@@ -72,7 +75,11 @@ function saveDocument(): void {
       </div>
 
       <div class="toolbar__actions" aria-label="Document actions">
-        <ToolbarButton v-if="props.isDesktop" :compact="props.isMobile" @click="openDocument">
+        <ToolbarButton
+          v-if="props.canOpenDocuments"
+          :compact="props.isMobile"
+          @click="openDocument"
+        >
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
             <path d="M2 5.5l6-3 6 3M2 5.5V13h12V5.5" />
             <path d="M6 8h4" />
@@ -80,7 +87,11 @@ function saveDocument(): void {
           <span>Open</span>
         </ToolbarButton>
 
-        <ToolbarButton v-if="props.isDesktop" :compact="props.isMobile" @click="saveDocument">
+        <ToolbarButton
+          v-if="props.canSaveDocuments"
+          :compact="props.isMobile"
+          @click="saveDocument"
+        >
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
             <path d="M3 2.5h8l2 2V13a1 1 0 01-1 1H4a1 1 0 01-1-1v-9.5z" />
             <path d="M5 2.5v4h5v-4" />

--- a/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -8,8 +8,9 @@ describe('Toolbar', () => {
     const wrapper = mount(Toolbar, {
       props: {
         availableModes: ['editor', 'split', 'preview'],
+        canOpenDocuments: true,
+        canSaveDocuments: true,
         isCopied: false,
-        isDesktop: true,
         isMobile: false,
         theme: 'light',
         viewMode: 'split',
@@ -28,8 +29,9 @@ describe('Toolbar', () => {
     const wrapper = mount(Toolbar, {
       props: {
         availableModes: ['editor', 'preview'],
+        canOpenDocuments: true,
+        canSaveDocuments: true,
         isCopied: false,
-        isDesktop: false,
         isMobile: true,
         theme: 'light',
         viewMode: 'editor',
@@ -43,5 +45,22 @@ describe('Toolbar', () => {
     expect(
       wrapper.find('.toolbar__mobile-controls button[aria-label="Switch to dark mode"]').exists(),
     ).toBe(true)
+  })
+
+  it('hides open and save when document actions are unavailable', () => {
+    const wrapper = mount(Toolbar, {
+      props: {
+        availableModes: ['editor', 'preview'],
+        canOpenDocuments: false,
+        canSaveDocuments: false,
+        isCopied: false,
+        isMobile: false,
+        theme: 'light',
+        viewMode: 'editor',
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Open')
+    expect(wrapper.text()).not.toContain('Save')
   })
 })

--- a/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
+++ b/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
@@ -19,6 +19,7 @@ const desktopMock = {
 
 describe('useDocumentActions', () => {
   const originalDesktop = window.desktop
+  const originalShowOpenFilePicker = window.showOpenFilePicker
   const originalCreateObjectURL = URL.createObjectURL
   const originalRevokeObjectURL = URL.revokeObjectURL
   const originalShowSaveFilePicker = window.showSaveFilePicker
@@ -26,18 +27,40 @@ describe('useDocumentActions', () => {
   beforeEach(() => {
     resetBrowserDocumentSessionForTests()
     window.desktop = undefined
-    window.showSaveFilePicker = originalShowSaveFilePicker
+    restoreOpenFilePicker()
+    restoreSaveFilePicker()
     vi.clearAllMocks()
   })
 
   afterEach(() => {
     resetBrowserDocumentSessionForTests()
     window.desktop = originalDesktop
-    window.showSaveFilePicker = originalShowSaveFilePicker
+    restoreOpenFilePicker()
+    restoreSaveFilePicker()
     URL.createObjectURL = originalCreateObjectURL
     URL.revokeObjectURL = originalRevokeObjectURL
     vi.restoreAllMocks()
   })
+
+  function restoreOpenFilePicker(): void {
+    const descriptor = {
+      configurable: true,
+      value: originalShowOpenFilePicker,
+      writable: true,
+    }
+    Object.defineProperty(window, 'showOpenFilePicker', descriptor)
+    Object.defineProperty(globalThis, 'showOpenFilePicker', descriptor)
+  }
+
+  function restoreSaveFilePicker(): void {
+    const descriptor = {
+      configurable: true,
+      value: originalShowSaveFilePicker,
+      writable: true,
+    }
+    Object.defineProperty(window, 'showSaveFilePicker', descriptor)
+    Object.defineProperty(globalThis, 'showSaveFilePicker', descriptor)
+  }
 
   it('reports document actions as available in the browser without the desktop bridge', () => {
     const actions = useDocumentActions()
@@ -100,77 +123,82 @@ describe('useDocumentActions', () => {
   })
 
   it('returns null when the browser open picker is canceled', async () => {
-    const actions = useDocumentActions()
-
-    const openPromise = actions.open()
-    const input = document.querySelector('input[type="file"]')
-
-    expect(input).toBeInstanceOf(HTMLInputElement)
-    input?.dispatchEvent(new Event('cancel'))
-
-    await expect(openPromise).resolves.toBe(null)
-    expect(document.querySelector('input[type="file"]')).toBeNull()
-  })
-
-  it('returns null when focus returns without a selected file', async () => {
-    const actions = useDocumentActions()
-
-    const openPromise = actions.open()
-    const input = document.querySelector('input[type="file"]')
-
-    expect(input).toBeInstanceOf(HTMLInputElement)
-    window.dispatchEvent(new Event('blur'))
-    window.dispatchEvent(new Event('focus'))
-
-    await expect(openPromise).resolves.toBe(null)
-    expect(document.querySelector('input[type="file"]')).toBeNull()
-  })
-
-  it('opens the selected browser file and cleans up the temporary input', async () => {
-    const actions = useDocumentActions()
-    const file = new File(['# Loaded'], 'loaded.md', { type: 'text/markdown' })
-
-    const openPromise = actions.open()
-    const input = document.querySelector('input[type="file"]')
-
-    expect(input).toBeInstanceOf(HTMLInputElement)
-    Object.defineProperty(input, 'files', {
-      configurable: true,
-      get: () => [file],
+    window.showOpenFilePicker = vi.fn(async () => {
+      throw new DOMException('Canceled', 'AbortError')
     })
-    input?.dispatchEvent(new Event('change'))
 
-    await expect(openPromise).resolves.toEqual({
+    const actions = useDocumentActions()
+
+    await expect(actions.open()).resolves.toBe(null)
+  })
+
+  it('reuses the browser file handle after opening with the file system access picker', async () => {
+    const actions = useDocumentActions()
+    const writes: string[] = []
+    const handle = {
+      createWritable: vi.fn(async () => ({
+        close: async () => undefined,
+        write: async (value: string) => {
+          writes.push(value)
+        },
+      })),
+      getFile: vi.fn(async () => new File(['# Loaded'], 'loaded.md', { type: 'text/markdown' })),
+      kind: 'file',
+      name: 'loaded.md',
+    } as unknown as FileSystemFileHandle
+
+    window.showOpenFilePicker = vi.fn(async () => [handle])
+    const showSaveFilePickerSpy = vi.fn()
+    window.showSaveFilePicker = showSaveFilePickerSpy
+
+    await expect(actions.open()).resolves.toEqual({
       content: '# Loaded',
       path: 'loaded.md',
     })
-    expect(document.querySelector('input[type="file"]')).toBeNull()
+
+    await expect(actions.save({ content: '# Updated', path: 'loaded.md' })).resolves.toEqual({
+      path: 'loaded.md',
+    })
+
+    expect(showSaveFilePickerSpy).not.toHaveBeenCalled()
+    expect(writes).toEqual(['# Updated'])
   })
 
-  it('returns null when reading the selected browser file fails', async () => {
+  it('returns null when reading a selected browser file fails', async () => {
     const actions = useDocumentActions()
-    const file = new File(['binary'], 'broken.md', { type: 'text/markdown' })
+    const handle = {
+      getFile: vi.fn(async () => new File(['binary'], 'broken.md', { type: 'text/markdown' })),
+      kind: 'file',
+      name: 'broken.md',
+    } as unknown as FileSystemFileHandle
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const readAsTextSpy = vi.spyOn(FileReader.prototype, 'readAsText').mockImplementation(() => {
       throw new DOMException('Denied', 'NotReadableError')
     })
 
-    const openPromise = actions.open()
-    const input = document.querySelector('input[type="file"]')
+    window.showOpenFilePicker = vi.fn(async () => [handle])
 
-    expect(input).toBeInstanceOf(HTMLInputElement)
-    Object.defineProperty(input, 'files', {
-      configurable: true,
-      get: () => [file],
-    })
-    input?.dispatchEvent(new Event('change'))
-
-    await expect(openPromise).resolves.toBe(null)
+    await expect(actions.open()).resolves.toBe(null)
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Failed to open the selected file:',
       expect.any(DOMException),
     )
     expect(readAsTextSpy).toHaveBeenCalled()
-    expect(document.querySelector('input[type="file"]')).toBeNull()
+  })
+
+  it('preserves the current document name when save falls back to download', async () => {
+    window.showSaveFilePicker = undefined
+
+    const actions = useDocumentActions()
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined)
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:actions')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    const saved = await actions.save({ content: '# Saved', path: 'notes.md' })
+
+    expect(saved).toEqual({ path: 'notes.md' })
+    expect(anchorClickSpy).toHaveBeenCalled()
   })
 })

--- a/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
+++ b/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetBrowserDocumentSessionForTests, useDocumentActions } from '../useDocumentActions'
+
+const desktopMock = {
+  commands: {
+    onAppCommand: vi.fn(() => () => undefined),
+  },
+  documents: {
+    open: vi.fn(async () => ({ content: '# Loaded', path: '/tmp/loaded.md' })),
+    save: vi.fn(async () => ({ path: '/tmp/saved.md' })),
+    saveAs: vi.fn(async () => ({ path: '/tmp/saved-as.md' })),
+  },
+  isDesktop: true,
+  shell: {
+    openExternal: vi.fn(async () => undefined),
+  },
+}
+
+describe('useDocumentActions', () => {
+  const originalDesktop = window.desktop
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  const originalShowSaveFilePicker = window.showSaveFilePicker
+
+  beforeEach(() => {
+    resetBrowserDocumentSessionForTests()
+    window.desktop = undefined
+    window.showSaveFilePicker = originalShowSaveFilePicker
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    resetBrowserDocumentSessionForTests()
+    window.desktop = originalDesktop
+    window.showSaveFilePicker = originalShowSaveFilePicker
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+    vi.restoreAllMocks()
+  })
+
+  it('reports document actions as available in the browser without the desktop bridge', () => {
+    const actions = useDocumentActions()
+
+    expect(actions.isDesktop.value).toBe(false)
+    expect(actions.canOpenDocuments.value).toBe(true)
+    expect(actions.canSaveDocuments.value).toBe(true)
+  })
+
+  it('delegates to the desktop bridge when available', async () => {
+    window.desktop = desktopMock
+
+    const actions = useDocumentActions()
+
+    await actions.open()
+    await actions.save({ content: '# Draft', path: null })
+    await actions.saveAs({ content: '# Draft', suggestedPath: 'draft.md' })
+
+    expect(actions.isDesktop.value).toBe(true)
+    expect(desktopMock.documents.open).toHaveBeenCalled()
+    expect(desktopMock.documents.save).toHaveBeenCalledWith({ content: '# Draft', path: null })
+    expect(desktopMock.documents.saveAs).toHaveBeenCalledWith({
+      content: '# Draft',
+      suggestedPath: 'draft.md',
+    })
+  })
+
+  it('falls back to download when the browser save picker is unavailable', async () => {
+    window.showSaveFilePicker = undefined
+
+    const actions = useDocumentActions()
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined)
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:actions')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    const saved = await actions.saveAs({ content: '# Saved', suggestedPath: 'browser-note' })
+
+    expect(saved).toEqual({ path: 'browser-note.md' })
+    expect(createObjectUrlSpy).toHaveBeenCalled()
+    expect(anchorClickSpy).toHaveBeenCalled()
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:actions')
+  })
+
+  it('returns null when the browser save picker is canceled', async () => {
+    window.showSaveFilePicker = vi.fn(async () => {
+      throw new DOMException('Canceled', 'AbortError')
+    })
+
+    const actions = useDocumentActions()
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined)
+
+    const saved = await actions.saveAs({ content: '# Saved', suggestedPath: 'browser-note.md' })
+
+    expect(saved).toBe(null)
+    expect(anchorClickSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the browser open picker is canceled', async () => {
+    const actions = useDocumentActions()
+
+    const openPromise = actions.open()
+    const input = document.querySelector('input[type="file"]')
+
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    input?.dispatchEvent(new Event('cancel'))
+
+    await expect(openPromise).resolves.toBe(null)
+    expect(document.querySelector('input[type="file"]')).toBeNull()
+  })
+
+  it('returns null when focus returns without a selected file', async () => {
+    const actions = useDocumentActions()
+
+    const openPromise = actions.open()
+    const input = document.querySelector('input[type="file"]')
+
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    window.dispatchEvent(new Event('blur'))
+    window.dispatchEvent(new Event('focus'))
+
+    await expect(openPromise).resolves.toBe(null)
+    expect(document.querySelector('input[type="file"]')).toBeNull()
+  })
+
+  it('opens the selected browser file and cleans up the temporary input', async () => {
+    const actions = useDocumentActions()
+    const file = new File(['# Loaded'], 'loaded.md', { type: 'text/markdown' })
+
+    const openPromise = actions.open()
+    const input = document.querySelector('input[type="file"]')
+
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      get: () => [file],
+    })
+    input?.dispatchEvent(new Event('change'))
+
+    await expect(openPromise).resolves.toEqual({
+      content: '# Loaded',
+      path: 'loaded.md',
+    })
+    expect(document.querySelector('input[type="file"]')).toBeNull()
+  })
+
+  it('returns null when reading the selected browser file fails', async () => {
+    const actions = useDocumentActions()
+    const file = new File(['binary'], 'broken.md', { type: 'text/markdown' })
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const readAsTextSpy = vi.spyOn(FileReader.prototype, 'readAsText').mockImplementation(() => {
+      throw new DOMException('Denied', 'NotReadableError')
+    })
+
+    const openPromise = actions.open()
+    const input = document.querySelector('input[type="file"]')
+
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      get: () => [file],
+    })
+    input?.dispatchEvent(new Event('change'))
+
+    await expect(openPromise).resolves.toBe(null)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to open the selected file:',
+      expect.any(DOMException),
+    )
+    expect(readAsTextSpy).toHaveBeenCalled()
+    expect(document.querySelector('input[type="file"]')).toBeNull()
+  })
+})

--- a/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
+++ b/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 
+import { resetBrowserDocumentSessionForTests } from '../useDocumentActions'
 import { useDocumentSession } from '../useDocumentSession'
 
 const desktopMock = {
@@ -18,29 +19,47 @@ const desktopMock = {
   },
 }
 
+function createSession(initialContent = '# Draft') {
+  const content = shallowRef(initialContent)
+  const session = useDocumentSession({
+    content,
+    replaceContent: (value) => {
+      content.value = value
+    },
+  })
+
+  return { content, session }
+}
+
 describe('useDocumentSession', () => {
   const originalDesktop = window.desktop
+  const originalConfirm = window.confirm
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  const originalShowSaveFilePicker = window.showSaveFilePicker
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    resetBrowserDocumentSessionForTests()
     window.desktop = desktopMock
+    window.confirm = vi.fn(() => true)
     vi.clearAllMocks()
     consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
+    resetBrowserDocumentSessionForTests()
     consoleWarnSpy.mockRestore()
     window.desktop = originalDesktop
+    window.confirm = originalConfirm
+    window.showSaveFilePicker = originalShowSaveFilePicker
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+    vi.restoreAllMocks()
   })
 
-  it('opens and replaces the current document content', async () => {
-    const content = shallowRef('# Draft')
-    const session = useDocumentSession({
-      content,
-      replaceContent: (value) => {
-        content.value = value
-      },
-    })
+  it('opens and replaces the current document content in desktop mode', async () => {
+    const { content, session } = createSession()
 
     await session.openDocument()
     await nextTick()
@@ -48,16 +67,12 @@ describe('useDocumentSession', () => {
     expect(content.value).toBe('# Loaded')
     expect(session.currentPath.value).toBe('/tmp/loaded.md')
     expect(session.isDirty.value).toBe(false)
+    expect(session.canOpenDocuments.value).toBe(true)
+    expect(session.canSaveDocuments.value).toBe(true)
   })
 
-  it('tracks dirty state and save branching', async () => {
-    const content = shallowRef('# Draft')
-    const session = useDocumentSession({
-      content,
-      replaceContent: (value) => {
-        content.value = value
-      },
-    })
+  it('tracks dirty state and save branching in desktop mode', async () => {
+    const { content, session } = createSession()
 
     content.value = '# Draft updated'
     await nextTick()
@@ -75,13 +90,7 @@ describe('useDocumentSession', () => {
   })
 
   it('handles app command routing', async () => {
-    const content = shallowRef('# Draft')
-    const session = useDocumentSession({
-      content,
-      replaceContent: (value) => {
-        content.value = value
-      },
-    })
+    const { session } = createSession()
 
     await session.handleAppCommand('document:saveAs')
 
@@ -90,17 +99,125 @@ describe('useDocumentSession', () => {
   })
 
   it('ignores unrelated app commands without saving', async () => {
-    const content = shallowRef('# Draft')
-    const session = useDocumentSession({
-      content,
-      replaceContent: (value) => {
-        content.value = value
-      },
-    })
+    const { session } = createSession()
 
     await session.handleAppCommand('document:new' as never)
 
     expect(desktopMock.documents.saveAs).not.toHaveBeenCalled()
     expect(consoleWarnSpy).toHaveBeenCalledWith('Unhandled app command: document:new')
+  })
+
+  it('opens a browser document and clears dirty state in web mode', async () => {
+    window.desktop = undefined
+
+    const { content, session } = createSession()
+    const file = new File(['# Web Loaded'], 'notes.md', { type: 'text/markdown' })
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(function mockClick(this: HTMLInputElement) {
+        Object.defineProperty(this, 'files', {
+          configurable: true,
+          value: [file],
+        })
+        this.dispatchEvent(new Event('change'))
+      })
+
+    content.value = '# Edited'
+    await nextTick()
+
+    await session.openDocument()
+    await nextTick()
+
+    expect(clickSpy).toHaveBeenCalled()
+    expect(content.value).toBe('# Web Loaded')
+    expect(session.currentPath.value).toBe('notes.md')
+    expect(session.isDirty.value).toBe(false)
+  })
+
+  it('downloads the current content when saving on the web without a persistent handle', async () => {
+    window.desktop = undefined
+    window.showSaveFilePicker = undefined
+
+    const { session } = createSession('# Download me')
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined)
+    const createObjectUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:markdown-studio')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+
+    await session.saveDocument()
+
+    expect(createObjectUrlSpy).toHaveBeenCalled()
+    expect(anchorClickSpy).toHaveBeenCalled()
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:markdown-studio')
+    expect(session.currentPath.value).toBe('Untitled.md')
+    expect(session.isDirty.value).toBe(false)
+  })
+
+  it('writes in place on the web after a persistent file handle is acquired', async () => {
+    window.desktop = undefined
+
+    const writes: string[] = []
+    const close = vi.fn(async () => undefined)
+    const write = vi.fn(async (value: string) => {
+      writes.push(value)
+    })
+    const createWritable = vi.fn(
+      async () =>
+        ({
+          close,
+          write,
+        }) as unknown as FileSystemWritableFileStream,
+    )
+    const fileHandle = {
+      createWritable,
+      kind: 'file',
+      name: 'saved-from-web.md',
+    } as unknown as FileSystemFileHandle
+    const showSaveFilePicker = vi.fn(async () => fileHandle)
+    window.showSaveFilePicker = showSaveFilePicker
+
+    const { content, session } = createSession('# First pass')
+
+    await session.saveDocumentAs()
+
+    content.value = '# Second pass'
+    await nextTick()
+
+    await session.saveDocument()
+
+    expect(showSaveFilePicker).toHaveBeenCalledTimes(1)
+    expect(createWritable).toHaveBeenCalledTimes(2)
+    expect(writes).toEqual(['# First pass', '# Second pass'])
+    expect(session.currentPath.value).toBe('saved-from-web.md')
+    expect(session.isDirty.value).toBe(false)
+  })
+
+  it('leaves the session unchanged when browser open or save is canceled', async () => {
+    window.desktop = undefined
+
+    const { content, session } = createSession('# Draft')
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(function mockClick(this: HTMLInputElement) {
+        Object.defineProperty(this, 'files', {
+          configurable: true,
+          value: [],
+        })
+        this.dispatchEvent(new Event('change'))
+      })
+    window.showSaveFilePicker = vi.fn(async () => {
+      throw new DOMException('Canceled', 'AbortError')
+    })
+
+    await session.openDocument()
+    await session.saveDocument()
+
+    expect(clickSpy).toHaveBeenCalled()
+    expect(content.value).toBe('# Draft')
+    expect(session.currentPath.value).toBe(null)
+    expect(session.isDirty.value).toBe(false)
   })
 })

--- a/src/features/markdown/composables/useDocumentActions.ts
+++ b/src/features/markdown/composables/useDocumentActions.ts
@@ -1,0 +1,275 @@
+import { computed, type ComputedRef } from 'vue'
+
+import { useDesktop } from '@/composables/useDesktop'
+
+interface BrowserOpenResult {
+  file: File
+  handle?: FileSystemFileHandle
+}
+
+interface DocumentActions {
+  canOpenDocuments: ComputedRef<boolean>
+  canSaveDocuments: ComputedRef<boolean>
+  clearCurrentDocumentReference: () => void
+  isDesktop: ComputedRef<boolean>
+  open: () => Promise<DocumentHandle | null>
+  save: (input: SaveDocumentInput) => Promise<{ path: string } | null>
+  saveAs: (input: SaveDocumentAsInput) => Promise<{ path: string } | null>
+}
+
+interface DocumentHandle {
+  content: string
+  path: string
+}
+
+interface SaveDocumentAsInput {
+  content: string
+  suggestedPath?: null | string
+}
+
+interface SaveDocumentInput {
+  content: string
+  path: null | string
+}
+
+export function useDocumentActions(): DocumentActions {
+  const desktop = useDesktop()
+
+  const isDesktop = computed(() => desktop.value.isDesktop)
+  const canOpenDocuments = computed(() => isDesktop.value || typeof window !== 'undefined')
+  const canSaveDocuments = computed(() => isDesktop.value || typeof window !== 'undefined')
+
+  async function open(): Promise<DocumentHandle | null> {
+    if (isDesktop.value) {
+      return desktop.value.documents.open()
+    }
+
+    const opened = await openBrowserDocument()
+    if (!opened) return null
+
+    try {
+      const content = await readFileAsText(opened.file)
+      browserSession.handle = opened.handle ?? null
+
+      return {
+        content,
+        path: opened.file.name,
+      }
+    } catch (error) {
+      console.error('Failed to open the selected file:', error)
+      return null
+    }
+  }
+
+  async function save(input: SaveDocumentInput): Promise<{ path: string } | null> {
+    if (isDesktop.value) {
+      return desktop.value.documents.save(input)
+    }
+
+    if (browserSession.handle) {
+      const path = await writeWithFileHandle(browserSession.handle, input.content)
+      return { path }
+    }
+
+    return saveAs(input)
+  }
+
+  async function saveAs(input: SaveDocumentAsInput): Promise<{ path: string } | null> {
+    if (isDesktop.value) {
+      return desktop.value.documents.saveAs(input)
+    }
+
+    const suggestedPath = getSuggestedPath(input.suggestedPath)
+    const handle = await showBrowserSavePicker(suggestedPath)
+
+    if (handle === null) {
+      return null
+    }
+
+    if (handle) {
+      const path = await writeWithFileHandle(handle, input.content)
+      browserSession.handle = handle
+      return { path }
+    }
+
+    downloadDocument(input.content, suggestedPath)
+    browserSession.handle = null
+    return { path: suggestedPath }
+  }
+
+  return {
+    canOpenDocuments,
+    canSaveDocuments,
+    clearCurrentDocumentReference,
+    isDesktop,
+    open,
+    save,
+    saveAs,
+  }
+}
+
+const browserSession: { handle: FileSystemFileHandle | null } = {
+  handle: null,
+}
+
+export function resetBrowserDocumentSessionForTests(): void {
+  clearCurrentDocumentReference()
+}
+
+function clearCurrentDocumentReference(): void {
+  browserSession.handle = null
+}
+
+function downloadDocument(content: string, fileName: string): void {
+  if (typeof document === 'undefined') return
+
+  const anchor = document.createElement('a')
+  const url = URL.createObjectURL(new Blob([content], { type: 'text/markdown;charset=utf-8' }))
+
+  anchor.href = url
+  anchor.download = fileName
+  anchor.style.display = 'none'
+  document.body.append(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+function getSuggestedPath(inputPath?: null | string): string {
+  if (!inputPath) {
+    return 'Untitled.md'
+  }
+
+  return inputPath.toLowerCase().endsWith('.md') ? inputPath : `${inputPath}.md`
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
+async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
+  if (typeof document === 'undefined') return null
+
+  const input = document.createElement('input')
+  input.type = 'file'
+  input.accept = '.md,.markdown,.mdown,text/markdown,text/plain'
+  input.style.display = 'none'
+
+  let resolveFile: (value: File | null) => void = () => undefined
+  let settled = false
+  let windowBlurred = false
+
+  const finish = (file: File | null): void => {
+    if (settled) return
+    settled = true
+    cleanup()
+    resolveFile(file)
+  }
+
+  const cleanup = (): void => {
+    input.removeEventListener('change', onChange)
+    input.removeEventListener('cancel', onCancel)
+    window.removeEventListener('blur', onWindowBlur)
+    window.removeEventListener('focus', onWindowFocus)
+    input.remove()
+  }
+
+  const onChange = (): void => {
+    finish(input.files?.[0] ?? null)
+  }
+
+  const onCancel = (): void => {
+    finish(null)
+  }
+
+  const onWindowBlur = (): void => {
+    windowBlurred = true
+  }
+
+  const onWindowFocus = (): void => {
+    if (!windowBlurred) return
+    finish(input.files?.[0] ?? null)
+  }
+
+  const file = await new Promise<File | null>((resolve) => {
+    resolveFile = resolve
+    input.addEventListener('change', onChange)
+    input.addEventListener('cancel', onCancel)
+    window.addEventListener('blur', onWindowBlur)
+    window.addEventListener('focus', onWindowFocus)
+
+    document.body?.append(input)
+    input.click()
+  })
+
+  return file ? { file } : null
+}
+
+async function readFileAsText(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.addEventListener(
+      'load',
+      () => {
+        resolve(typeof reader.result === 'string' ? reader.result : '')
+      },
+      { once: true },
+    )
+    reader.addEventListener(
+      'error',
+      () => {
+        reject(reader.error ?? new Error('Failed to read the selected file.'))
+      },
+      { once: true },
+    )
+
+    reader.readAsText(file)
+  })
+}
+
+async function showBrowserSavePicker(
+  suggestedName: string,
+): Promise<FileSystemFileHandle | null | undefined> {
+  if (typeof window === 'undefined' || typeof window.showSaveFilePicker !== 'function') {
+    return undefined
+  }
+
+  try {
+    return await window.showSaveFilePicker({
+      excludeAcceptAllOption: false,
+      suggestedName,
+      types: [
+        {
+          accept: { 'text/markdown': ['.md', '.markdown', '.mdown'] },
+          description: 'Markdown Files',
+        },
+      ],
+    })
+  } catch (error) {
+    if (isAbortError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+async function writeWithFileHandle(handle: FileSystemFileHandle, content: string): Promise<string> {
+  const writable = await handle.createWritable()
+  let writeError: unknown
+
+  try {
+    await writable.write(content)
+  } catch (error) {
+    writeError = error
+  } finally {
+    await writable.close()
+  }
+
+  if (writeError) {
+    throw writeError
+  }
+
+  return handle.name
+}

--- a/src/features/markdown/composables/useDocumentActions.ts
+++ b/src/features/markdown/composables/useDocumentActions.ts
@@ -71,7 +71,10 @@ export function useDocumentActions(): DocumentActions {
       return { path }
     }
 
-    return saveAs(input)
+    return saveAs({
+      content: input.content,
+      suggestedPath: input.path,
+    })
   }
 
   async function saveAs(input: SaveDocumentAsInput): Promise<{ path: string } | null> {
@@ -148,6 +151,11 @@ function isAbortError(error: unknown): boolean {
 }
 
 async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
+  const openedWithHandle = await showBrowserOpenPicker()
+  if (openedWithHandle !== undefined) {
+    return openedWithHandle
+  }
+
   if (typeof document === 'undefined') return null
 
   const input = document.createElement('input')
@@ -226,6 +234,43 @@ async function readFileAsText(file: Blob): Promise<string> {
 
     reader.readAsText(file)
   })
+}
+
+async function showBrowserOpenPicker(): Promise<BrowserOpenResult | null | undefined> {
+  if (typeof window === 'undefined' || typeof window.showOpenFilePicker !== 'function') {
+    return undefined
+  }
+
+  try {
+    const [handle] = await window.showOpenFilePicker({
+      excludeAcceptAllOption: false,
+      multiple: false,
+      types: [
+        {
+          accept: {
+            'text/markdown': ['.md', '.markdown', '.mdown'],
+            'text/plain': ['.txt'],
+          },
+          description: 'Markdown Files',
+        },
+      ],
+    })
+
+    if (!handle) {
+      return null
+    }
+
+    return {
+      file: await handle.getFile(),
+      handle,
+    }
+  } catch (error) {
+    if (isAbortError(error)) {
+      return null
+    }
+
+    throw error
+  }
 }
 
 async function showBrowserSavePicker(

--- a/src/features/markdown/composables/useDocumentSession.ts
+++ b/src/features/markdown/composables/useDocumentSession.ts
@@ -1,3 +1,5 @@
+import type { AppCommand } from '@electron/shared/types'
+
 import {
   computed,
   type ComputedRef,
@@ -8,9 +10,7 @@ import {
   watch,
 } from 'vue'
 
-import { useDesktop } from '@/composables/useDesktop'
-
-import type { AppCommand } from '../../../../electron/shared/types'
+import { useDocumentActions } from './useDocumentActions'
 
 interface UseDocumentSessionOptions {
   content: DeepReadonly<ShallowRef<string>>
@@ -18,6 +18,8 @@ interface UseDocumentSessionOptions {
 }
 
 interface UseDocumentSessionReturn {
+  canOpenDocuments: ComputedRef<boolean>
+  canSaveDocuments: ComputedRef<boolean>
   currentPath: DeepReadonly<ShallowRef<null | string>>
   displayName: ComputedRef<string>
   handleAppCommand: (command: AppCommand) => Promise<void>
@@ -31,12 +33,12 @@ interface UseDocumentSessionReturn {
 }
 
 export function useDocumentSession(options: UseDocumentSessionOptions): UseDocumentSessionReturn {
-  const desktop = useDesktop()
+  const documents = useDocumentActions()
   const currentPath = shallowRef<null | string>(null)
   const lastAction = shallowRef('Ready')
   const savedContent = shallowRef(options.content.value)
 
-  const isDesktop = computed(() => desktop.value.isDesktop)
+  const { canOpenDocuments, canSaveDocuments, isDesktop } = documents
   const isDirty = computed(() => options.content.value !== savedContent.value)
   const displayName = computed(() =>
     currentPath.value ? getFileName(currentPath.value) : 'Untitled.md',
@@ -66,7 +68,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   async function openDocument(): Promise<void> {
     if (!(await confirmDiscardChanges())) return
 
-    const opened = await desktop.value.documents.open()
+    const opened = await documents.open()
     if (!opened) return
 
     options.replaceContent(opened.content)
@@ -77,7 +79,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   }
 
   async function saveDocument(): Promise<void> {
-    const saved = await desktop.value.documents.save({
+    const saved = await documents.save({
       content: options.content.value,
       path: currentPath.value,
     })
@@ -91,7 +93,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   }
 
   async function saveDocumentAs(): Promise<void> {
-    const saved = await desktop.value.documents.saveAs({
+    const saved = await documents.saveAs({
       content: options.content.value,
       suggestedPath: currentPath.value ?? displayName.value,
     })
@@ -107,6 +109,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   async function startNewDocument(): Promise<void> {
     if (!(await confirmDiscardChanges())) return
 
+    documents.clearCurrentDocumentReference()
     options.replaceContent('')
     currentPath.value = null
     savedContent.value = ''
@@ -134,6 +137,8 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   watch([displayName, isDirty, isDesktop], syncDocumentTitle, { immediate: true })
 
   return {
+    canOpenDocuments,
+    canSaveDocuments,
     currentPath: readonly(currentPath),
     displayName,
     handleAppCommand,

--- a/src/views/MarkdownStudioView.vue
+++ b/src/views/MarkdownStudioView.vue
@@ -31,9 +31,10 @@ const {
 } = useMarkdownEditor()
 const desktop = useDesktop()
 const {
+  canOpenDocuments,
+  canSaveDocuments,
   displayName,
   handleAppCommand,
-  isDesktop,
   isDirty,
   openDocument,
   saveDocument,
@@ -217,7 +218,8 @@ watch(
   <div class="markdown-studio" :class="bodyClasses">
     <Toolbar
       :available-modes="availableModes"
-      :is-desktop="isDesktop"
+      :can-open-documents="canOpenDocuments"
+      :can-save-documents="canSaveDocuments"
       :is-mobile="isMobile"
       :view-mode="viewMode"
       :theme="theme"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,10 +5,12 @@
   "compilerOptions": {
     // Extra safety for array and object lookups, but may have false positives.
     "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
 
     // Path mapping for cleaner imports.
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@electron/*": ["./electron/*"]
     },
 
     // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -4,6 +4,10 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@electron/*": ["./electron/*"]
+    },
     "types": ["node", "electron", "electron-vite/node"],
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.electron.tsbuildinfo"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "./tsconfig.electron.json"
+    },
+    {
+      "path": "./cypress/tsconfig.json"
     }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@electron': fileURLToPath(new URL('./electron', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- Add shared document action/session handling so the editor can run in both web and Electron contexts
- Wire desktop document operations through preload, IPC, and menu integration while keeping browser behavior safe
- Update toolbar, view, and environment typing to reflect the new document action flow
- Refresh validation and end-to-end coverage for the document workflows

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm type-check`
- Updated unit and Cypress coverage for document actions and session behavior