### PR TITLE
Add npx-compatible CLI packaging and release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Desktop
+name: Release Desktop + npm
 
 on:
   push:
@@ -14,12 +14,13 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 jobs:
   preflight:
     name: Preflight
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.release_meta.outputs.version }}
       tag: ${{ steps.release_meta.outputs.tag }}
@@ -71,7 +72,7 @@ jobs:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
           node-version-file: package.json
@@ -91,26 +92,14 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
-      - name: Stamp release version
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        run: |
-          node --input-type=module <<'EOF'
-          import { readFile, writeFile } from 'node:fs/promises'
-
-          const packageJsonPath = new URL('./package.json', `file://${process.cwd()}/`)
-          const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
-
-          packageJson.version = process.env.RELEASE_VERSION
-
-          await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
-          EOF
+      - name: Align package versions to release version
+        run: node ./scripts/update-release-package-versions.mjs "${{ needs.preflight.outputs.version }}"
 
       - name: Build desktop artifacts
         run: pnpm dist:mac
 
       - name: Upload release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: markdown-studio-macos
           path: |
@@ -118,13 +107,59 @@ jobs:
             release/*.zip
           if-no-files-found: error
 
+  publish_npm:
+    name: Publish npm package
+    needs: [preflight, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Align package versions to release version
+        run: node ./scripts/update-release-package-versions.mjs "${{ needs.preflight.outputs.version }}"
+
+      - name: Build npm package
+        run: pnpm build:npm
+
+      - name: Verify npm package contents
+        run: pnpm --dir packages/cli pack:check
+
+      - name: Publish npm package
+        shell: bash
+        working-directory: packages/cli
+        run: |
+          npm_tag=latest
+
+          if [[ "${{ needs.preflight.outputs.is_prerelease }}" == "true" ]]; then
+            npm_tag=next
+          fi
+
+          npm publish --provenance --tag "$npm_tag"
+
   release:
     name: Publish GitHub release
-    needs: [preflight, build]
-    runs-on: ubuntu-latest
+    needs: [preflight, build, publish_npm]
+    runs-on: ubuntu-24.04
     steps:
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: markdown-studio-macos
           path: release-assets
@@ -146,7 +181,7 @@ jobs:
   finalize:
     name: Finalize release
     needs: [preflight, release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -159,7 +194,7 @@ jobs:
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
           node-version-file: package.json
@@ -167,32 +202,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Update package version
-        env:
-          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
-        run: |
-          node --input-type=module <<'EOF'
-          import { readFile, writeFile } from 'node:fs/promises'
+      - name: Update package versions
+        run: node ./scripts/update-release-package-versions.mjs "${{ needs.preflight.outputs.version }}"
 
-          const packageJsonPath = new URL('./package.json', `file://${process.cwd()}/`)
-          const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
-
-          packageJson.version = process.env.RELEASE_VERSION
-
-          await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
-          EOF
-
-      - name: Format package.json
+      - name: Format package manifests
         run: pnpm format
 
       - name: Create version bump pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: package.json
+          add-paths: |
+            package.json
+            packages/cli/package.json
           base: main
           branch: release/${{ needs.preflight.outputs.tag }}-version-bump
           commit-message: 'chore(release): prepare ${{ needs.preflight.outputs.tag }}'
           delete-branch: true
           title: 'chore(release): prepare ${{ needs.preflight.outputs.tag }}'
           body: |
-            Updates `package.json` to the released version after publishing `${{ needs.preflight.outputs.tag }}`.
+            Updates the package manifests to the released version after publishing `${{ needs.preflight.outputs.tag }}`.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 out
 release
 coverage
+.tmp
 *.local
 
 # Editor directories and files
@@ -40,3 +41,7 @@ __screenshots__/
 
 # Vite
 *.timestamp-*-*.mjs
+
+# Packaged npm launcher outputs
+packages/cli/dist
+packages/cli/public

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Prefer workspace dependencies over registry equivalents
+prefer-workspace-packages=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Run `pnpm format`, `pnpm lint`, and `pnpm type-check` before considering a task complete.
 - Before running a script command that uses `vite preview`, don't forget to build the app first.
 - If tests are relevant to the change, run the smallest targeted suite first, then expand only if needed. Prefer `pnpm test:unit`, `pnpm test:e2e:dev`, or `pnpm test:e2e` over ad hoc commands.
+- When running a specific single test file in Vitest, use the `pnpm exec vitest run` command; e.g.: `pnpm exec vitest run src/__tests__/App.spec.ts`.
 - Do not use outdated or redundant scripts when a repo-specific command already exists.
 
 ## Project Snapshot

--- a/README.md
+++ b/README.md
@@ -18,33 +18,33 @@ Markdown Studio is a split-pane Markdown editor that lets you write on one side 
 - Example templates to get you started
 - Available as a web app or desktop application
 
-## Features
+## Quick Start
 
-### For Writers
+### Run via NPX (No installation required)
 
-- **Split-pane editor** — Write on the left, preview on the right
-- **View modes** — Toggle between split view, editor-only, or preview-only modes
-- **Live Markdown rendering** — See changes instantly as you type
-- **Mermaid diagram support** — Create flowcharts, sequence diagrams, ER diagrams, and Gantt charts using simple text syntax
-- **Theme switching** — Toggle between light and dark modes with smooth animated transitions
-- **Document statistics** — Track word, character, line, and diagram counts in real-time
-- **Example documents** — Load pre-made templates to learn Markdown or Mermaid syntax
-- **Copy to clipboard** — Quickly copy your Markdown source with visual feedback
+```sh
+npx markdown-studio@latest
+```
 
-### For Developers
+With optional flags:
 
-- **Safe HTML rendering** — Content is sanitized with DOMPurify
-- **File System Access API** — Open and save files directly in supported browsers
-- **Desktop file operations** — Full file management in the Electron app
-- **Responsive design** — Works on desktop and mobile devices
-- **Keyboard shortcuts** — Efficient editing with familiar shortcuts
-- **Scroll synchronization** — Source map tracking enables editor-preview sync
+```sh
+npx markdown-studio@latest --port 4173
+npx markdown-studio@latest --host 127.0.0.1 --no-open
+npx markdown-studio@latest --version
+```
 
-## Getting Started
+The launcher serves the production web build over `http://127.0.0.1` and opens your browser automatically. This is the web experience, not the Electron app, so browser file APIs and fallbacks still apply.
 
-### Web App
+**Browser behavior:**
 
-Visit the app in your browser (after running the dev server):
+- Chromium browsers can use the File System Access API on `localhost`
+- Other browsers fall back to the existing picker and download flows
+- The server is local-only by default because it binds to `127.0.0.1`
+
+### Web App (Development)
+
+Visit the app in your browser by running the dev server:
 
 ```sh
 pnpm install
@@ -79,6 +79,28 @@ pnpm dist:mac
 > ```
 >
 > **Alternative:** Open `System Settings` → `Privacy & Security` and allow the app to run from there.
+
+## Features
+
+### For Writers
+
+- **Split-pane editor** — Write on the left, preview on the right
+- **View modes** — Toggle between split view, editor-only, or preview-only modes
+- **Live Markdown rendering** — See changes instantly as you type
+- **Mermaid diagram support** — Create flowcharts, sequence diagrams, ER diagrams, and Gantt charts using simple text syntax
+- **Theme switching** — Toggle between light and dark modes with smooth animated transitions
+- **Document statistics** — Track word, character, line, and diagram counts in real-time
+- **Example documents** — Load pre-made templates to learn Markdown or Mermaid syntax
+- **Copy to clipboard** — Quickly copy your Markdown source with visual feedback
+
+### For Developers
+
+- **Safe HTML rendering** — Content is sanitized with DOMPurify
+- **File System Access API** — Open and save files directly in supported browsers
+- **Desktop file operations** — Full file management in the Electron app
+- **Responsive design** — Works on desktop and mobile devices
+- **Keyboard shortcuts** — Efficient editing with familiar shortcuts
+- **Scroll synchronization** — Source map tracking enables editor-preview sync
 
 ## Usage
 
@@ -172,6 +194,11 @@ electron/                  # Electron main process code
 ├── shared/                # Shared types and validation
 ├── main.ts                # Electron entry point
 └── preload.ts             # Preload script for secure IPC
+
+packages/cli/              # NPX launcher package
+├── src/                   # CLI source code
+├── public/                # Packaged web assets
+└── dist/                  # Built CLI output
 ```
 
 ### Tech Stack
@@ -200,6 +227,7 @@ pnpm dev:desktop      # Start Electron in dev mode
 
 # Building
 pnpm build            # Build for production
+pnpm build:npm        # Build and stage the npm launcher package
 pnpm build:desktop    # Build Electron bundles
 pnpm dist:mac         # Create unsigned macOS package
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -45,6 +45,7 @@ export default defineConfigWithVueTs(
     '**/out/**',
     '**/release/**',
     '**/coverage/**',
+    'packages/cli/public/**',
     '**/node_modules/**',
     'eslint.config.ts',
   ]),
@@ -65,7 +66,7 @@ export default defineConfigWithVueTs(
 
   {
     ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/*'],
+    files: ['src/**/__tests__/*', 'packages/**/__tests__/*'],
   },
 
   {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-studio",
+  "name": "markdown-studio-monorepo",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check \"build-only {@}\" --",
+    "build:web": "pnpm build-only",
+    "build:npm": "pnpm build:web && node ./scripts/stage-cli-package.mjs && pnpm --dir packages/cli build",
     "build:desktop": "electron-vite build",
     "dev:desktop": "electron-vite dev --watch",
     "dist:mac": "pnpm build:desktop && electron-builder --mac --config.mac.identity=null --publish never",
@@ -21,6 +23,7 @@
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
+    "pack:npm": "pnpm build:npm && pnpm --dir packages/cli pack:check",
     "format": "oxfmt",
     "format:check": "oxfmt --check"
   },

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The Markdown Studio Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,100 @@
+# markdown-studio
+
+Launch Markdown Studio locally in your browser from an npm package.
+
+## Quick Start
+
+```sh
+npx markdown-studio@latest
+```
+
+## Installation
+
+### Global Install
+
+```sh
+npm install -g markdown-studio
+markdown-studio
+```
+
+### NPX (No installation)
+
+```sh
+npx markdown-studio@latest
+```
+
+## Usage
+
+```sh
+markdown-studio [options]
+```
+
+### Options
+
+| Option            | Description                       | Default               |
+| ----------------- | --------------------------------- | --------------------- |
+| `--host <host>`   | Host to bind to                   | `127.0.0.1`           |
+| `--port <number>` | Port to listen on                 | Random available port |
+| `--no-open`       | Do not open browser automatically | `false`               |
+| `--version, -v`   | Show version number               | -                     |
+| `--help, -h`      | Show help message                 | -                     |
+
+### Examples
+
+Start on default host and random port (browser opens automatically):
+
+```sh
+npx markdown-studio@latest
+```
+
+Start on specific port:
+
+```sh
+npx markdown-studio@latest --port 4173
+```
+
+Start on all interfaces without opening browser:
+
+```sh
+npx markdown-studio@latest --host 0.0.0.0 --no-open
+```
+
+Show version:
+
+```sh
+npx markdown-studio@latest --version
+```
+
+## How It Works
+
+This package serves the production Markdown Studio web app over localhost and opens your default browser. It delivers the browser experience, not the Electron desktop shell, so native desktop-only file integration is not included.
+
+### Browser Behavior
+
+- **Chromium browsers** can use the File System Access API on `localhost`
+- **Other browsers** fall back to the existing picker and download flows
+- The server is **local-only** by default because it binds to `127.0.0.1`
+
+## Development
+
+### Build
+
+```sh
+pnpm build
+```
+
+### Test Locally
+
+After building, you can test the CLI locally:
+
+```sh
+# From the packages/cli directory
+node dist/cli.mjs
+
+# Or using npx with local path
+npx ./packages/cli
+```
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "markdown-studio",
+  "version": "0.1.0",
+  "description": "Launch Markdown Studio locally in your browser from an npm package.",
+  "keywords": [
+    "editor",
+    "markdown",
+    "mermaid",
+    "npx",
+    "vite",
+    "vue"
+  ],
+  "license": "MIT",
+  "bin": {
+    "markdown-studio": "./dist/cli.mjs"
+  },
+  "files": [
+    "dist",
+    "public",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "pnpm exec tsc -p ./tsconfig.build.json && node ./scripts/finalize-dist.mjs",
+    "prepack": "node ./scripts/verify-package.mjs && pnpm build",
+    "pack:check": "pnpm pack --pack-destination ../../.tmp/npm-pack"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/packages/cli/scripts/finalize-dist.mjs
+++ b/packages/cli/scripts/finalize-dist.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * Distribution finalization script.
+ *
+ * Converts .js files to .mjs and rewrites internal imports to use .mjs extensions.
+ * This ensures the package can be consumed as an ES module.
+ */
+
+import { readFile, rename, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Root directory of the CLI package.
+ */
+const packageDir = fileURLToPath(new URL('..', import.meta.url))
+
+/**
+ * Directory containing built distribution files.
+ */
+const distDir = path.join(packageDir, 'dist')
+
+/**
+ * Module files to convert from .js to .mjs.
+ */
+const moduleFiles = ['browser', 'cli', 'server']
+
+// Process each module file
+for (const moduleFile of moduleFiles) {
+  const jsPath = path.join(distDir, `${moduleFile}.js`)
+  const mjsPath = path.join(distDir, `${moduleFile}.mjs`)
+
+  // Read the source file
+  const source = await readFile(jsPath, 'utf8')
+
+  // Rewrite internal .js imports to .mjs
+  const rewritten = source.replaceAll(/(\.\/[\w-]+)\.js(['"])/g, '$1.mjs$2')
+
+  // Write the rewritten content back
+  await writeFile(jsPath, rewritten, 'utf8')
+
+  // Remove existing .mjs if present
+  await rm(mjsPath, { force: true })
+
+  // Rename .js to .mjs
+  await rename(jsPath, mjsPath)
+}

--- a/packages/cli/scripts/verify-package.mjs
+++ b/packages/cli/scripts/verify-package.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+/**
+ * Package verification script.
+ *
+ * Ensures all required files exist before packaging the CLI.
+ * Throws an error if any required assets are missing.
+ */
+
+import { access } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Root directory of the CLI package.
+ */
+const packageDir = fileURLToPath(new URL('..', import.meta.url))
+
+/**
+ * List of required paths that must exist for a valid package.
+ */
+const requiredPaths = [
+  path.join(packageDir, 'public/index.html'),
+  path.join(packageDir, 'src/cli.ts'),
+  path.join(packageDir, 'src/server.ts'),
+]
+
+// Verify each required path exists
+for (const requiredPath of requiredPaths) {
+  try {
+    await access(requiredPath)
+  } catch {
+    throw new Error(
+      `Missing required package asset: ${requiredPath}. Run "pnpm build:npm" from the repository root before packing.`,
+    )
+  }
+}

--- a/packages/cli/src/__tests__/browser.spec.ts
+++ b/packages/cli/src/__tests__/browser.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const spawnMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}))
+
+import { openBrowser } from '../browser'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+
+  spawnMock.mockReset()
+})
+
+describe('openBrowser', () => {
+  it('escapes Windows cmd metacharacters in the opened URL', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    })
+
+    spawnMock.mockImplementation((_file, _args, _options) => {
+      const child = {
+        unref: vi.fn(),
+      }
+
+      return {
+        on(event: string, handler: () => void) {
+          if (event === 'spawn') {
+            handler()
+          }
+
+          return child
+        },
+        unref: child.unref,
+      }
+    })
+
+    await openBrowser('https://example.com/?a=1&b=2%25')
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'cmd',
+      ['/c', 'start', '', 'https://example.com/?a=1^&b=2%%25'],
+      {
+        detached: false,
+        stdio: 'ignore',
+      },
+    )
+  })
+
+  it('rejects unsupported URL protocols', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    })
+
+    await expect(openBrowser('javascript:alert(1)')).rejects.toThrow(
+      'Unsupported browser URL protocol: javascript:',
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed URLs', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    })
+
+    await expect(openBrowser('not a url')).rejects.toThrow('Invalid browser URL: not a url')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/cli.spec.ts
+++ b/packages/cli/src/__tests__/cli.spec.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+import { assertFreshPackagedAssets, getVersion, parseArgs } from '../cli'
+
+describe('parseArgs', () => {
+  it('uses localhost defaults', async () => {
+    expect(await parseArgs([])).toEqual({
+      host: '127.0.0.1',
+      openBrowser: true,
+    })
+  })
+
+  it('parses host, port, and no-open flags', async () => {
+    expect(await parseArgs(['--host', '0.0.0.0', '--port', '4173', '--no-open'])).toEqual({
+      host: '0.0.0.0',
+      openBrowser: false,
+      port: 4173,
+    })
+  })
+
+  it('rejects invalid ports', async () => {
+    await expect(() => parseArgs(['--port', '70000'])).rejects.toThrow('Invalid port: 70000')
+  })
+
+  it('exits with version when --version flag is provided', async () => {
+    const versionSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    try {
+      await expect(() => parseArgs(['--version'])).rejects.toThrow('process.exit')
+
+      const version = await getVersion()
+      expect(versionSpy).toHaveBeenCalledWith(version)
+    } finally {
+      versionSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('exits with version when -v flag is provided', async () => {
+    const versionSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    try {
+      await expect(() => parseArgs(['-v'])).rejects.toThrow('process.exit')
+
+      const version = await getVersion()
+      expect(versionSpy).toHaveBeenCalledWith(version)
+    } finally {
+      versionSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('returns the package version from getVersion', async () => {
+    const version = await getVersion()
+    expect(version).toBeDefined()
+    expect(typeof version).toBe('string')
+    // Version should follow semver format (e.g., "0.1.3")
+    expect(version).toMatch(/^\d+\.\d+\.\d+/)
+  })
+})
+
+describe('assertFreshPackagedAssets', () => {
+  it('passes for the current staged build', async () => {
+    await expect(assertFreshPackagedAssets()).resolves.toBeUndefined()
+  })
+
+  it('detects stale packaged assets relative to the source build', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'markdown-studio-cli-'))
+    const sourceDir = path.join(tempRoot, 'dist')
+    const packagedDir = path.join(tempRoot, 'packages/cli/public')
+
+    try {
+      await mkdir(sourceDir, { recursive: true })
+      await mkdir(packagedDir, { recursive: true })
+
+      await Promise.all([
+        writeFile(path.join(sourceDir, 'index.html'), '<html>source</html>', 'utf8'),
+        writeFile(path.join(packagedDir, 'index.html'), '<html>packaged</html>', 'utf8'),
+      ])
+
+      await expect(
+        assertFreshPackagedAssets({
+          assetsDir: packagedDir,
+          sourceBuildDir: sourceDir,
+        }),
+      ).rejects.toThrow('Packaged web assets are stale')
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
+  })
+})

--- a/packages/cli/src/__tests__/server.spec.ts
+++ b/packages/cli/src/__tests__/server.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  BadRequestError,
+  getPublicHost,
+  getPublicUrl,
+  getRequestPath,
+  resolveRequestTarget,
+} from '../server'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })))
+})
+
+describe('resolveRequestTarget', () => {
+  it('serves the app shell and static assets', async () => {
+    const assetsDir = await createFixture()
+    const [html, css] = await Promise.all([
+      resolveRequestTarget(assetsDir, '/'),
+      resolveRequestTarget(assetsDir, '/assets/index.css'),
+    ])
+
+    expect(html.filePath).toBe(path.join(assetsDir, 'index.html'))
+    expect(html.headers['Content-Type']).toBe('text/html; charset=utf-8')
+    expect(css.filePath).toBe(path.join(assetsDir, 'assets/index.css'))
+    expect(css.headers['Cache-Control']).toBe('public, max-age=31536000, immutable')
+  })
+
+  it('falls back to index.html for app routes and returns 404 for missing assets', async () => {
+    const assetsDir = await createFixture()
+    const [routeResponse, missingAsset] = await Promise.all([
+      resolveRequestTarget(assetsDir, '/documents/demo'),
+      resolveRequestTarget(assetsDir, '/assets/missing.js'),
+    ])
+
+    expect(routeResponse.filePath).toBe(path.join(assetsDir, 'index.html'))
+    expect(missingAsset.statusCode).toBe(404)
+  })
+
+  it('maps wildcard hosts to a browser-safe URL', () => {
+    expect(getPublicHost('0.0.0.0')).toBe('127.0.0.1')
+    expect(getPublicHost('::')).toBe('::1')
+    expect(getPublicHost('[::]')).toBe('::1')
+    expect(getPublicUrl('127.0.0.1', 43219)).toBe('http://127.0.0.1:43219')
+    expect(getPublicUrl('::1', 43219)).toBe('http://[::1]:43219')
+    expect(getPublicUrl('fe80::1%en0', 43219)).toBe('http://[fe80::1%en0]:43219')
+  })
+
+  it('rejects malformed percent-encoding with a bad request error', () => {
+    expect(() => getRequestPath('/%')).toThrow(BadRequestError)
+    expect(() => getRequestPath('/%')).toThrow('Invalid percent-encoding in request URL')
+  })
+})
+
+async function createFixture(): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'markdown-studio-cli-'))
+  tempDirs.push(tempDir)
+
+  await mkdir(path.join(tempDir, 'assets'), { recursive: true })
+  await Promise.all([
+    writeFile(
+      path.join(tempDir, 'index.html'),
+      '<!doctype html><html><body><div id="app"></div></body></html>',
+      'utf8',
+    ),
+    writeFile(path.join(tempDir, 'assets/index.css'), 'body { color: red; }', 'utf8'),
+  ])
+
+  return tempDir
+}

--- a/packages/cli/src/browser.ts
+++ b/packages/cli/src/browser.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process'
+
+/**
+ * Opens the default web browser to the specified URL.
+ *
+ * Detects the platform and uses the appropriate command:
+ * - macOS: `open`
+ * - Windows: `cmd /c start`
+ * - Linux/other: `xdg-open`
+ *
+ * @param url - The URL to open
+ */
+export async function openBrowser(url: string): Promise<void> {
+  const command = getOpenCommand(url)
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command.file, command.args, {
+      detached: process.platform !== 'win32',
+      stdio: 'ignore',
+    })
+
+    child.on('error', reject)
+    child.on('spawn', () => {
+      child.unref()
+      resolve()
+    })
+  })
+}
+
+function escapeCmdUrl(value: string): string {
+  return value
+    .replaceAll('^', '^^')
+    .replaceAll('&', '^&')
+    .replaceAll('|', '^|')
+    .replaceAll('>', '^>')
+    .replaceAll('<', '^<')
+    .replaceAll('%', '%%')
+    .replaceAll('"', '""')
+}
+
+/**
+ * Returns the platform-specific command to open a URL.
+ *
+ * @param url - The URL to open
+ * @returns Object with file (command) and args (arguments)
+ */
+function getOpenCommand(url: string): { args: string[]; file: string } {
+  const normalizedUrl = validateBrowserUrl(url)
+
+  if (process.platform === 'darwin') {
+    return { args: [normalizedUrl], file: 'open' }
+  }
+
+  if (process.platform === 'win32') {
+    return {
+      args: ['/c', 'start', '', escapeCmdUrl(normalizedUrl)],
+      file: 'cmd',
+    }
+  }
+
+  return { args: [normalizedUrl], file: 'xdg-open' }
+}
+
+function validateBrowserUrl(value: string): string {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error(`Invalid browser URL: ${value}`)
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`Unsupported browser URL protocol: ${parsed.protocol}`)
+  }
+
+  return parsed.toString()
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import { realpathSync } from 'node:fs'
+import { access, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { openBrowser } from './browser.js'
+import { startStaticServer } from './server.js'
+
+/**
+ * CLI options for running Markdown Studio.
+ */
+interface CliOptions {
+  /** Host to bind the server to */
+  host: string
+  /** Whether to automatically open the browser */
+  openBrowser: boolean
+  /** Optional port to listen on (defaults to random available port) */
+  port?: number
+}
+
+/**
+ * Help text displayed when --help or -h flag is used.
+ */
+const HELP_TEXT = `Markdown Studio
+
+Usage:
+  markdown-studio [--host <host>] [--port <number>] [--no-open] [--version]
+
+Options:
+  --host <host>     Host to bind to (default: 127.0.0.1)
+  --port <number>   Port to listen on (default: random available port)
+  --no-open         Do not open browser automatically
+  --version, -v     Show version number
+  --help, -h        Show this help message
+`
+
+/**
+ * Path to the public assets directory.
+ */
+const assetsDir = fileURLToPath(new URL('../public', import.meta.url))
+
+/**
+ * Path to the source build directory.
+ */
+const sourceBuildDir = fileURLToPath(new URL('../../../dist', import.meta.url))
+
+/**
+ * Cached version string to avoid repeated file reads.
+ */
+let cachedVersion: string | undefined
+
+/**
+ * Asserts that the packaged web assets are up-to-date with the source build.
+ *
+ * Throws an error if:
+ * - Packaged assets are missing
+ * - Packaged assets are stale compared to source build
+ *
+ * @param paths - Optional paths to check. Defaults to constants.
+ * @throws Error if packaged assets are missing or stale
+ */
+export async function assertFreshPackagedAssets(
+  paths: {
+    assetsDir: string
+    sourceBuildDir: string
+  } = {
+    assetsDir,
+    sourceBuildDir,
+  },
+): Promise<void> {
+  const [hasSourceBuild, hasPackagedBuild] = await Promise.all([
+    pathExists(paths.sourceBuildDir),
+    pathExists(paths.assetsDir),
+  ])
+
+  if (!hasPackagedBuild) {
+    throw new Error('Missing packaged web assets. Run "pnpm build:npm" before starting the CLI.')
+  }
+
+  if (!hasSourceBuild) {
+    return
+  }
+
+  const [sourceIndex, packagedIndex] = await Promise.all([
+    readFile(path.join(paths.sourceBuildDir, 'index.html'), 'utf8'),
+    readFile(path.join(paths.assetsDir, 'index.html'), 'utf8'),
+  ])
+
+  if (sourceIndex !== packagedIndex) {
+    throw new Error(
+      'Packaged web assets are stale. Run "pnpm build:npm" so packages/cli/public matches the current web build.',
+    )
+  }
+}
+
+/**
+ * Reads the version from the package.json file.
+ * Uses readFile to directly parse package.json, which works in both development and production.
+ */
+export async function getVersion(): Promise<string> {
+  if (cachedVersion) {
+    return cachedVersion
+  }
+  const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url))
+  const packageJsonContent = await readFile(packageJsonPath, 'utf8')
+  const packageJson = JSON.parse(packageJsonContent) as { version: string }
+  cachedVersion = packageJson.version
+  return cachedVersion
+}
+
+/**
+ * Parses command-line arguments into CLI options.
+ *
+ * Supports: --host, --port, --no-open, --version, --help
+ *
+ * @param args - Command-line arguments (typically process.argv.slice(2))
+ * @returns Parsed CLI options
+ * @throws Error for unknown arguments or missing values
+ */
+export async function parseArgs(args: string[]): Promise<CliOptions> {
+  const options: CliOptions = {
+    host: '127.0.0.1',
+    openBrowser: true,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+
+    if (arg === '--help' || arg === '-h') {
+      console.log(HELP_TEXT)
+      process.exit(0)
+    }
+
+    if (arg === '--version' || arg === '-v') {
+      const version = await getVersion()
+      console.log(version)
+      process.exit(0)
+    }
+
+    if (arg === '--no-open') {
+      options.openBrowser = false
+      continue
+    }
+
+    if (arg === '--host') {
+      const nextValue = args[index + 1]
+      if (!nextValue) {
+        throw new Error('Missing value for --host')
+      }
+
+      options.host = nextValue
+      index += 1
+      continue
+    }
+
+    if (arg === '--port') {
+      const nextValue = args[index + 1]
+      if (!nextValue) {
+        throw new Error('Missing value for --port')
+      }
+
+      const parsed = Number.parseInt(nextValue, 10)
+      if (Number.isNaN(parsed) || parsed < 0 || parsed > 65535) {
+        throw new Error(`Invalid port: ${nextValue}`)
+      }
+
+      options.port = parsed
+      index += 1
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return options
+}
+
+/**
+ * Main entry point for the CLI.
+ *
+ * Parses arguments, validates assets, starts the server, opens the browser,
+ * and sets up shutdown handlers.
+ */
+async function main(): Promise<void> {
+  const options = await parseArgs(process.argv.slice(2))
+  await assertFreshPackagedAssets()
+  const server = await startStaticServer({
+    assetsDir,
+    host: options.host,
+    port: options.port,
+  })
+
+  console.log(`Markdown Studio is running at ${server.url}`)
+
+  if (options.openBrowser) {
+    try {
+      await openBrowser(server.url)
+    } catch (error) {
+      console.warn(`Failed to open the browser automatically. Open ${server.url} manually.`, error)
+    }
+  }
+
+  const shutdown = async () => {
+    process.off('SIGINT', shutdown)
+    process.off('SIGTERM', shutdown)
+    await server.close()
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+/**
+ * Checks if a path exists on the filesystem.
+ *
+ * @param targetPath - Path to check
+ * @returns true if path exists, false otherwise
+ */
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (import.meta.url === new URL(realpathSync.native(process.argv[1]), 'file://').href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,0 +1,312 @@
+import { createReadStream } from 'node:fs'
+import { access, stat } from 'node:fs/promises'
+import http from 'node:http'
+import path from 'node:path'
+
+/**
+ * Represents a running HTTP server with metadata.
+ */
+export interface RunningServer {
+  /** Function to close the server */
+  close: () => Promise<void>
+  /** Host address the server is bound to */
+  host: string
+  /** Port number the server is listening on */
+  port: number
+  /** The underlying Node.js HTTP server */
+  server: http.Server
+  /** Full URL to access the server */
+  url: string
+}
+
+/**
+ * Options for starting the static file server.
+ */
+export interface StartServerOptions {
+  /** Directory containing static assets to serve */
+  assetsDir: string
+  /** Host to bind the server to */
+  host: string
+  /** Optional port to listen on (defaults to random available port) */
+  port?: number
+}
+
+/**
+ * MIME content types mapped by file extension.
+ */
+const CONTENT_TYPES = new Map<string, string>([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.map', 'application/json; charset=utf-8'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml; charset=utf-8'],
+  ['.txt', 'text/plain; charset=utf-8'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+])
+
+/**
+ * Error thrown when a client sends an invalid request URL.
+ */
+export class BadRequestError extends Error {
+  /** HTTP status code associated with the error. */
+  statusCode = 400
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'BadRequestError'
+  }
+}
+
+/**
+ * Returns a public-facing host address.
+ *
+ * Converts 0.0.0.0 to 127.0.0.1 for display purposes.
+ *
+ * @param host - The bound host address
+ * @returns A public-accessible host address
+ */
+export function getPublicHost(host: string): string {
+  if (host === '0.0.0.0') {
+    return '127.0.0.1'
+  }
+
+  if (host === '::' || host === '[::]') {
+    return '::1'
+  }
+
+  return host
+}
+
+/**
+ * Constructs a public URL from host and port.
+ *
+ * @param host - Host address
+ * @param port - Port number
+ * @returns Full HTTP URL
+ */
+export function getPublicUrl(host: string, port: number): string {
+  const publicHost =
+    host.includes(':') && !(host.startsWith('[') && host.endsWith(']')) ? `[${host}]` : host
+
+  return `http://${publicHost}:${port}`
+}
+
+/**
+ * Extracts and decodes the pathname from a request URL.
+ *
+ * @param requestUrl - The request URL string
+ * @returns Decoded pathname
+ */
+export function getRequestPath(requestUrl: string | undefined): string {
+  const url = new URL(requestUrl ?? '/', 'http://localhost')
+
+  try {
+    return decodeURIComponent(url.pathname)
+  } catch {
+    throw new BadRequestError('Invalid percent-encoding in request URL')
+  }
+}
+
+/**
+ * Resolves a request path to a filesystem path within the assets directory.
+ *
+ * Prevents directory traversal attacks by ensuring the resolved path
+ * is within the assets directory. Falls back to index.html for paths
+ * without extensions.
+ *
+ * @param assetsDir - Root directory for static assets
+ * @param requestPath - Request pathname
+ * @returns Resolved filesystem path
+ */
+export function resolveAssetPath(assetsDir: string, requestPath: string): string {
+  const normalizedPath = path.posix.normalize(requestPath)
+  const relativePath = normalizedPath.replace(/^\/+/, '')
+  const candidate = path.resolve(assetsDir, relativePath)
+  const relativeToAssets = path.relative(assetsDir, candidate)
+
+  if (relativeToAssets.startsWith('..') || path.isAbsolute(relativeToAssets)) {
+    return path.join(assetsDir, 'index.html')
+  }
+
+  return relativePath === '' ? path.join(assetsDir, 'index.html') : candidate
+}
+
+/**
+ * Resolves a request to a file target with appropriate headers and status.
+ *
+ * Handles 404s, sets proper cache headers based on file type, and determines
+ * the appropriate content type.
+ *
+ * @param assetsDir - Root directory for static assets
+ * @param requestUrl - The request URL string
+ * @returns Resolution result with file path, headers, and status code
+ */
+export async function resolveRequestTarget(
+  assetsDir: string,
+  requestUrl: string | undefined,
+): Promise<{
+  filePath: null | string
+  headers: Record<string, string>
+  statusCode: 200 | 404
+}> {
+  const requestPath = getRequestPath(requestUrl)
+  const resolvedPath = resolveAssetPath(assetsDir, requestPath)
+  const fallbackPath = path.join(assetsDir, 'index.html')
+
+  const filePath = (await fileExists(resolvedPath))
+    ? resolvedPath
+    : shouldServeAppShell(requestPath)
+      ? fallbackPath
+      : null
+
+  if (!filePath) {
+    return {
+      filePath: null,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      statusCode: 404,
+    }
+  }
+
+  return {
+    filePath,
+    headers: {
+      'Cache-Control': filePath.endsWith('.html')
+        ? 'no-cache'
+        : requestPath.startsWith('/assets/')
+          ? 'public, max-age=31536000, immutable'
+          : 'public, max-age=3600',
+      'Content-Type': CONTENT_TYPES.get(path.extname(filePath)) ?? 'application/octet-stream',
+    },
+    statusCode: 200,
+  }
+}
+
+/**
+ * Determines if a request should serve the app shell (index.html).
+ *
+ * Requests without file extensions are considered app shell requests.
+ *
+ * @param requestPath - Request pathname
+ * @returns true if the request should serve index.html
+ */
+export function shouldServeAppShell(requestPath: string): boolean {
+  return path.posix.extname(requestPath) === ''
+}
+
+/**
+ * Starts a static file server for the Markdown Studio app.
+ *
+ * Serves files from the assets directory with appropriate caching headers.
+ * Automatically finds an available port if none is specified.
+ *
+ * @param options - Server configuration options
+ * @returns Running server instance with close method and metadata
+ */
+export async function startStaticServer(options: StartServerOptions): Promise<RunningServer> {
+  const server = http.createServer(async (request, response) => {
+    try {
+      await handleRequest(options.assetsDir, request, response)
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
+        response.end('Bad Request')
+        return
+      }
+
+      response.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' })
+      response.end('Internal Server Error')
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(options.port ?? 0, options.host, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to determine the listening address.')
+  }
+
+  const externalHost = getPublicHost(options.host)
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      }),
+    host: address.address,
+    port: address.port,
+    server,
+    url: getPublicUrl(externalHost, address.port),
+  }
+}
+
+/**
+ * Checks if a file exists on the filesystem.
+ *
+ * @param filePath - Path to check
+ * @returns true if file exists, false otherwise
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Handles an incoming HTTP request.
+ *
+ * Resolves the requested file, streams it to the response, or returns
+ * a 404 if not found.
+ *
+ * @param assetsDir - Root directory for static assets
+ * @param request - Incoming HTTP request
+ * @param response - HTTP server response
+ */
+async function handleRequest(
+  assetsDir: string,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+): Promise<void> {
+  const resolution = await resolveRequestTarget(assetsDir, request.url)
+
+  if (resolution.statusCode === 404 || !resolution.filePath) {
+    response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+    response.end('Not Found')
+    return
+  }
+
+  const assetPath = resolution.filePath
+  const assetStat = await stat(assetPath)
+  if (!assetStat.isFile()) {
+    response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+    response.end('Not Found')
+    return
+  }
+
+  response.writeHead(resolution.statusCode, resolution.headers)
+
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(assetPath)
+    stream.on('error', reject)
+    stream.on('end', resolve)
+    stream.pipe(response)
+  })
+}

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": false,
+    "sourceMap": false
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
+  "compilerOptions": {
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "./src",
+    "types": ["node"],
+    "tsBuildInfoFile": "../../node_modules/.tmp/packages-cli.tsbuildinfo"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,8 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
 
+  packages/cli: {}
+
 packages:
 
   7zip-bin@5.2.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - packages/*
+
 allowBuilds:
   cypress: true
   electron: true

--- a/scripts/stage-cli-package.mjs
+++ b/scripts/stage-cli-package.mjs
@@ -1,0 +1,11 @@
+import { cp, mkdir, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = fileURLToPath(new URL('..', import.meta.url))
+const webDistDir = path.join(rootDir, 'dist')
+const cliPublicDir = path.join(rootDir, 'packages/cli/public')
+
+await rm(cliPublicDir, { force: true, recursive: true })
+await mkdir(path.dirname(cliPublicDir), { recursive: true })
+await cp(webDistDir, cliPublicDir, { recursive: true })

--- a/scripts/update-release-package-versions.mjs
+++ b/scripts/update-release-package-versions.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises'
+
+const version = process.argv[2]
+
+if (!version) {
+  console.error('Usage: node scripts/update-release-package-versions.mjs <version>')
+  process.exit(1)
+}
+
+const packageJsonPaths = ['./package.json', './packages/cli/package.json']
+
+await Promise.all(
+  packageJsonPaths.map(async (packageJsonPath) => {
+    const packageJsonUrl = new URL(packageJsonPath, `file://${process.cwd()}/`)
+    const packageJson = JSON.parse(await readFile(packageJsonUrl, 'utf8'))
+
+    packageJson.version = version
+
+    await writeFile(packageJsonUrl, `${JSON.stringify(packageJson, null, 2)}\n`)
+  }),
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "./tsconfig.electron.json"
     },
     {
+      "path": "./packages/cli/tsconfig.json"
+    },
+    {
       "path": "./cypress/tsconfig.json"
     }
   ]


### PR DESCRIPTION
## Summary

- Add a packaged CLI workspace with browser, server, and command entrypoints
- Make the CLI publishable and npx-friendly with package verification, dist finalization, and release version updates
- Update release automation, workspace config, and documentation to match the new packaging flow
- Refresh tests for CLI behavior and packaging expectations

## Testing

- pnpm format
- pnpm lint
- pnpm type-check
- pnpm test:unit