### PR TITLE
Add pull request checks and prerelease release placeholder

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,101 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality and unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version-file: package.json
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format
+        run: pnpm format
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
+  npm_package:
+    name: Build and verify npm package
+    runs-on: ubuntu-24.04
+    needs: quality
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build npm package
+        run: pnpm build:npm
+
+      - name: Verify npm package contents
+        run: pnpm --dir packages/cli pack:check
+
+  desktop_build:
+    name: Build macOS desktop release
+    runs-on: macos-latest
+    needs: quality
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version-file: package.json
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop artifacts
+        run: pnpm dist:mac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,25 @@ jobs:
             release/*.zip
           if-no-files-found: error
 
+  prerelease_placeholder:
+    name: Create prerelease placeholder
+    if: needs.preflight.outputs.is_prerelease == 'true'
+    needs: preflight
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create visible prerelease entry
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.tag }}
+          target_commitish: ${{ needs.preflight.outputs.ref }}
+          name: Markdown Studio v${{ needs.preflight.outputs.version }}
+          prerelease: true
+          make_latest: false
+          body: |
+            Prerelease publishing is in progress.
+
+            This entry is created before build and npm publish complete so failed prerelease runs remain visible in the Releases page.
+
   publish_npm:
     name: Publish npm package
     needs: [preflight, build]

--- a/packages/cli/src/__tests__/cli.spec.ts
+++ b/packages/cli/src/__tests__/cli.spec.ts
@@ -71,8 +71,49 @@ describe('parseArgs', () => {
 })
 
 describe('assertFreshPackagedAssets', () => {
-  it('passes for the current staged build', async () => {
-    await expect(assertFreshPackagedAssets()).resolves.toBeUndefined()
+  it('passes when packaged assets match the source build', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'markdown-studio-cli-'))
+    const sourceDir = path.join(tempRoot, 'dist')
+    const packagedDir = path.join(tempRoot, 'packages/cli/public')
+
+    try {
+      await mkdir(sourceDir, { recursive: true })
+      await mkdir(packagedDir, { recursive: true })
+
+      await Promise.all([
+        writeFile(path.join(sourceDir, 'index.html'), '<html>same</html>', 'utf8'),
+        writeFile(path.join(packagedDir, 'index.html'), '<html>same</html>', 'utf8'),
+      ])
+
+      await expect(
+        assertFreshPackagedAssets({
+          assetsDir: packagedDir,
+          sourceBuildDir: sourceDir,
+        }),
+      ).resolves.toBeUndefined()
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
+  })
+
+  it('fails when packaged assets are missing', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'markdown-studio-cli-'))
+    const sourceDir = path.join(tempRoot, 'dist')
+    const packagedDir = path.join(tempRoot, 'packages/cli/public')
+
+    try {
+      await mkdir(sourceDir, { recursive: true })
+      await writeFile(path.join(sourceDir, 'index.html'), '<html>source</html>', 'utf8')
+
+      await expect(
+        assertFreshPackagedAssets({
+          assetsDir: packagedDir,
+          sourceBuildDir: sourceDir,
+        }),
+      ).rejects.toThrow('Missing packaged web assets')
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true })
+    }
   })
 
   it('detects stale packaged assets relative to the source build', async () => {


### PR DESCRIPTION
## Summary
- Add a dedicated pull request workflow that runs format, lint, type-check, unit tests, npm package verification, and a macOS desktop build
- Create a visible prerelease placeholder entry during release runs so failed prerelease attempts remain discoverable
- Expand CLI asset freshness tests to cover matching, missing, and stale packaged assets

## Testing
- Not run (not requested)