### PR TITLE
Add PR checks workflow and harden prerelease packaging validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,19 @@
   "name": "markdown-studio-monorepo",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://github.com/theoklitosBam7/markdown-studio#readme",
+  "bugs": {
+    "url": "https://github.com/theoklitosBam7/markdown-studio/issues"
+  },
+  "author": {
+    "name": "Theoklitos Bampouris",
+    "email": "th.bampouris@gmail.com",
+    "url": "https://github.com/theoklitosBam7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theoklitosBam7/markdown-studio"
+  },
   "type": "module",
   "main": "out/main/main.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,9 +10,23 @@
     "vite",
     "vue"
   ],
+  "homepage": "https://github.com/theoklitosBam7/markdown-studio#readme",
+  "bugs": {
+    "url": "https://github.com/theoklitosBam7/markdown-studio/issues"
+  },
   "license": "MIT",
+  "author": {
+    "name": "Theoklitos Bampouris",
+    "email": "th.bampouris@gmail.com",
+    "url": "https://github.com/theoklitosBam7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theoklitosBam7/markdown-studio",
+    "directory": "packages/cli"
+  },
   "bin": {
-    "markdown-studio": "./dist/cli.mjs"
+    "markdown-studio": "dist/cli.mjs"
   },
   "files": [
     "dist",

--- a/packages/cli/scripts/verify-package.mjs
+++ b/packages/cli/scripts/verify-package.mjs
@@ -7,7 +7,7 @@
  * Throws an error if any required assets are missing.
  */
 
-import { access } from 'node:fs/promises'
+import { access, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -15,11 +15,14 @@ import { fileURLToPath } from 'node:url'
  * Root directory of the CLI package.
  */
 const packageDir = fileURLToPath(new URL('..', import.meta.url))
+const packageJsonPath = path.join(packageDir, 'package.json')
+const expectedRepositoryUrl = 'https://github.com/theoklitosBam7/markdown-studio'
 
 /**
  * List of required paths that must exist for a valid package.
  */
 const requiredPaths = [
+  packageJsonPath,
   path.join(packageDir, 'public/index.html'),
   path.join(packageDir, 'src/cli.ts'),
   path.join(packageDir, 'src/server.ts'),
@@ -34,4 +37,36 @@ for (const requiredPath of requiredPaths) {
       `Missing required package asset: ${requiredPath}. Run "pnpm build:npm" from the repository root before packing.`,
     )
   }
+}
+
+/**
+ * @typedef {{
+ *   bugs?: { url?: string }
+ *   homepage?: string
+ *   repository?: { directory?: string, type?: string, url?: string } | string
+ * }} PackageJsonMetadata
+ */
+
+/** @type {PackageJsonMetadata} */
+const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+
+const repositoryUrl =
+  typeof packageJson.repository === 'string' ? packageJson.repository : packageJson.repository?.url
+
+if (repositoryUrl !== expectedRepositoryUrl) {
+  throw new Error(
+    `Invalid package repository URL: expected "${expectedRepositoryUrl}", received "${repositoryUrl ?? ''}".`,
+  )
+}
+
+if (packageJson.homepage !== `${expectedRepositoryUrl}#readme`) {
+  throw new Error(
+    `Invalid package homepage: expected "${expectedRepositoryUrl}#readme", received "${packageJson.homepage ?? ''}".`,
+  )
+}
+
+if (packageJson.bugs?.url !== `${expectedRepositoryUrl}/issues`) {
+  throw new Error(
+    `Invalid package bugs URL: expected "${expectedRepositoryUrl}/issues", received "${packageJson.bugs?.url ?? ''}".`,
+  )
 }


### PR DESCRIPTION
## Summary
- add a pull request workflow that runs format, lint, type-check, unit tests, npm package verification, and macOS desktop build checks
- create a visible prerelease placeholder release entry so failed prerelease runs still appear in GitHub Releases
- expand CLI asset freshness tests to cover matching assets and missing packaged assets

## Testing
- Not run (not requested)