### PR TITLE
fix(useDocumentActions): harden browser document open fallback

### DIFF
--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -38,6 +38,50 @@ function stubBrowserOpen(win: BrowserWindow, fileName: string, content: string):
     ] satisfies FileSystemFileHandle[]
 }
 
+function stubBrowserOpenFallbackInput(
+  win: BrowserWindow,
+  fileName: string,
+  content: string,
+  options?: { delayMs?: number; pickerError?: DOMException },
+): void {
+  const originalCreateElement = win.document.createElement.bind(win.document)
+  const selectedFile = new win.File([content], fileName, { type: 'text/markdown' })
+
+  if (options?.pickerError) {
+    win.showOpenFilePicker = async () => {
+      throw options.pickerError
+    }
+  } else {
+    win.showOpenFilePicker = undefined
+  }
+
+  win.document.createElement = ((tagName: string, elementOptions?: ElementCreationOptions) => {
+    const element = originalCreateElement(tagName, elementOptions)
+
+    if (tagName.toLowerCase() === 'input') {
+      const input = element as HTMLInputElement
+      const originalClick = input.click.bind(input)
+
+      input.click = () => {
+        originalClick()
+        win.dispatchEvent(new win.Event('blur'))
+        win.dispatchEvent(new win.Event('focus'))
+
+        win.setTimeout(() => {
+          Object.defineProperty(input, 'files', {
+            configurable: true,
+            value: [selectedFile],
+          })
+
+          input.dispatchEvent(new win.Event('change'))
+        }, options?.delayMs ?? 0)
+      }
+    }
+
+    return element
+  }) as typeof win.document.createElement
+}
+
 function stubBrowserSavePicker(win: BrowserWindow, writes: string[], fileName: string): void {
   win.showSaveFilePicker = async () =>
     ({
@@ -114,6 +158,40 @@ describe('Markdown Studio responsive shell', () => {
     cy.get('textarea').should('have.value', '# Imported from Cypress')
     cy.get('.status-item--document').should('contain', 'web-notes.md')
     cy.get('.status-bar').should('contain', 'Opened web-notes.md')
+  })
+
+  it('opens a markdown file when the browser file input change arrives after focus returns', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        stubBrowserOpenFallbackInput(win, 'brave-delayed.md', '# Loaded via fallback', {
+          delayMs: 50,
+        })
+      },
+    })
+
+    cy.get('.toolbar__actions').contains('button', 'Open').click()
+
+    cy.get('textarea').should('have.value', '# Loaded via fallback')
+    cy.get('.status-item--document').should('contain', 'brave-delayed.md')
+    cy.get('.status-bar').should('contain', 'Opened brave-delayed.md')
+  })
+
+  it('falls back to the browser file input when showOpenFilePicker fails', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        stubBrowserOpenFallbackInput(win, 'picker-fallback.md', '# Recovered from picker error', {
+          pickerError: new win.DOMException('Denied', 'SecurityError'),
+        })
+      },
+    })
+
+    cy.get('.toolbar__actions').contains('button', 'Open').click()
+
+    cy.get('textarea').should('have.value', '# Recovered from picker error')
+    cy.get('.status-item--document').should('contain', 'picker-fallback.md')
+    cy.get('.status-bar').should('contain', 'Opened picker-fallback.md')
   })
 
   it('downloads markdown from the web toolbar when no persistent file handle exists', () => {

--- a/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
+++ b/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
@@ -39,6 +39,7 @@ describe('useDocumentActions', () => {
     restoreSaveFilePicker()
     URL.createObjectURL = originalCreateObjectURL
     URL.revokeObjectURL = originalRevokeObjectURL
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -130,6 +131,76 @@ describe('useDocumentActions', () => {
     const actions = useDocumentActions()
 
     await expect(actions.open()).resolves.toBe(null)
+  })
+
+  it('waits for a delayed file input change event after the window regains focus', async () => {
+    window.showOpenFilePicker = undefined
+
+    const actions = useDocumentActions()
+    vi.useFakeTimers()
+
+    const selectedFile = new File(['# Loaded from fallback'], 'fallback.md', {
+      type: 'text/markdown',
+    })
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(function mockClick(this: HTMLInputElement) {
+        window.dispatchEvent(new Event('blur'))
+        window.dispatchEvent(new Event('focus'))
+
+        window.setTimeout(() => {
+          Object.defineProperty(this, 'files', {
+            configurable: true,
+            value: [selectedFile],
+          })
+
+          this.dispatchEvent(new Event('change'))
+        }, 50)
+      })
+
+    const openPromise = actions.open()
+    await vi.runAllTimersAsync()
+
+    await expect(openPromise).resolves.toEqual({
+      content: '# Loaded from fallback',
+      path: 'fallback.md',
+    })
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('falls back to the file input when the browser open picker fails', async () => {
+    const pickerError = new DOMException('Denied', 'SecurityError')
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const selectedFile = new File(['# Fallback file'], 'fallback-from-picker.md', {
+      type: 'text/markdown',
+    })
+
+    window.showOpenFilePicker = vi.fn(async () => {
+      throw pickerError
+    })
+
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(function mockClick(this: HTMLInputElement) {
+        Object.defineProperty(this, 'files', {
+          configurable: true,
+          value: [selectedFile],
+        })
+
+        this.dispatchEvent(new Event('change'))
+      })
+
+    const actions = useDocumentActions()
+
+    await expect(actions.open()).resolves.toEqual({
+      content: '# Fallback file',
+      path: 'fallback-from-picker.md',
+    })
+    expect(clickSpy).toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Falling back to the browser file input after picker failure:',
+      pickerError,
+    )
   })
 
   it('reuses the browser file handle after opening with the file system access picker', async () => {

--- a/src/features/markdown/composables/useDocumentActions.ts
+++ b/src/features/markdown/composables/useDocumentActions.ts
@@ -151,9 +151,13 @@ function isAbortError(error: unknown): boolean {
 }
 
 async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
-  const openedWithHandle = await showBrowserOpenPicker()
-  if (openedWithHandle !== undefined) {
-    return openedWithHandle
+  try {
+    const openedWithHandle = await showBrowserOpenPicker()
+    if (openedWithHandle !== undefined) {
+      return openedWithHandle
+    }
+  } catch (error) {
+    console.warn('Falling back to the browser file input after picker failure:', error)
   }
 
   if (typeof document === 'undefined') return null
@@ -166,6 +170,7 @@ async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
   let resolveFile: (value: File | null) => void = () => undefined
   let settled = false
   let windowBlurred = false
+  let focusTimeoutId: null | number = null
 
   const finish = (file: File | null): void => {
     if (settled) return
@@ -175,6 +180,11 @@ async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
   }
 
   const cleanup = (): void => {
+    if (focusTimeoutId !== null) {
+      window.clearTimeout(focusTimeoutId)
+      focusTimeoutId = null
+    }
+
     input.removeEventListener('change', onChange)
     input.removeEventListener('cancel', onCancel)
     window.removeEventListener('blur', onWindowBlur)
@@ -196,7 +206,15 @@ async function openBrowserDocument(): Promise<BrowserOpenResult | null> {
 
   const onWindowFocus = (): void => {
     if (!windowBlurred) return
-    finish(input.files?.[0] ?? null)
+
+    if (focusTimeoutId !== null) {
+      window.clearTimeout(focusTimeoutId)
+    }
+
+    focusTimeoutId = window.setTimeout(() => {
+      focusTimeoutId = null
+      finish(input.files?.[0] ?? null)
+    }, 300)
   }
 
   const file = await new Promise<File | null>((resolve) => {


### PR DESCRIPTION
## Summary

- Fix `useDocumentActions` to fall back to the browser file input when `showOpenFilePicker` fails with an error
- Handle delayed file input change events that arrive after the window regains focus
- Add unit tests for both fallback scenarios
- Add Cypress e2e tests for Brave browser compatibility

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Test Procedure

- Unit tests: `pnpm test:unit`
- E2E tests: `pnpm test:e2e`

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123") -->

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
