### PR TITLE
feat(app): add update checker with semver support

### DIFF
--- a/.changeset/update-checker-feature.md
+++ b/.changeset/update-checker-feature.md
@@ -1,0 +1,5 @@
+---
+'@markdown-studio/desktop': minor
+---
+
+Add update checker with semver support for detecting and notifying users of app updates

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,8 +1,11 @@
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'electron-vite'
 import { builtinModules } from 'node:module'
+import { createRequire } from 'node:module'
 import { fileURLToPath, URL } from 'node:url'
 import vueDevTools from 'vite-plugin-vue-devtools'
+
+const desktopPackage = createRequire(import.meta.url)('./package.json')
 
 const electronRuntimeExternals = [
   'electron',
@@ -60,6 +63,9 @@ export default defineConfig({
       rollupOptions: {
         input: 'index.html',
       },
+    },
+    define: {
+      __APP_VERSION__: JSON.stringify(desktopPackage.version),
     },
     plugins: [vue(), vueDevTools()],
     resolve: {

--- a/apps/desktop/electron/menu/appMenu.ts
+++ b/apps/desktop/electron/menu/appMenu.ts
@@ -9,6 +9,7 @@ export function buildAppMenu(mainWindow: BrowserWindow): Menu {
       label: 'Markdown Studio',
       submenu: [
         { role: 'about' },
+        createCommandMenuItem(mainWindow, 'Check for Updates…', '', 'update:check'),
         { type: 'separator' },
         { role: 'services' },
         { type: 'separator' },

--- a/apps/desktop/tsconfig.app.json
+++ b/apps/desktop/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*.ts", "src/**/*.vue"],
+  "include": ["env.d.ts", "src/**/*.ts", "src/**/*.vue", "../../packages/app/src/**/*.d.ts"],
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*.ts"],
+  "include": ["env.d.ts", "src/**/*.ts", "../../packages/app/src/**/*.d.ts"],
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@changesets/cli": "^2.29.7",
     "@tsconfig/node24": "^24.0.4",
     "@types/node": "^24.12.0",
+    "@types/semver": "^7.7.1",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/eslint-plugin": "^1.6.13",
     "@vue/eslint-config-typescript": "^14.7.0",
@@ -66,6 +67,7 @@
     "npm-run-all2": "^8.0.4",
     "oxfmt": "^0.41.0",
     "oxlint": "~1.56.0",
+    "semver": "^7.7.4",
     "start-server-and-test": "^2.1.5",
     "typescript": "~5.9.3",
     "vue-tsc": "^3.2.6"

--- a/packages/app/src/browser-globals.d.ts
+++ b/packages/app/src/browser-globals.d.ts
@@ -3,6 +3,8 @@
 import type { DesktopApi } from '@markdown-studio/desktop-contract/types'
 
 declare global {
+  const __APP_VERSION__: string | undefined
+
   interface Window {
     desktop?: DesktopApi
     showOpenFilePicker?: (options?: unknown) => Promise<FileSystemFileHandle[]>

--- a/packages/app/src/composables/useUpdateChecker.ts
+++ b/packages/app/src/composables/useUpdateChecker.ts
@@ -1,0 +1,191 @@
+import { computed, readonly, shallowRef } from 'vue'
+
+import { useDesktop } from '@/composables/useDesktop'
+import { compareSemver } from '@/utils/semver'
+
+export type ManualCheckStatus = 'checking' | 'idle' | 'up-to-date'
+
+export interface UpdateInfo {
+  currentVersion: string
+  latestVersion: string
+  releaseUrl: string
+}
+
+const DISMISSED_KEY = 'update-banner-dismissed'
+const LAST_CHECK_KEY = 'update-last-check'
+const UP_TO_DATE_DISPLAY_MS = 7000
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+const INITIAL_DELAY_MS = 5000
+
+const RELEASES_URL = 'https://api.github.com/repos/theoklitosBam7/markdown-studio/releases/latest'
+
+export function useUpdateChecker() {
+  const desktop = useDesktop()
+  const updateInfo = shallowRef<null | UpdateInfo>(null)
+  const isDismissed = shallowRef(false)
+  const manualCheckStatus = shallowRef<ManualCheckStatus>('idle')
+
+  let upToDateTimeoutId: ReturnType<typeof setTimeout> | undefined
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let intervalId: ReturnType<typeof setInterval> | undefined
+
+  function readLastCheck(): number {
+    if (typeof localStorage === 'undefined') return 0
+    const raw = localStorage.getItem(LAST_CHECK_KEY)
+    return raw ? Number(raw) : 0
+  }
+
+  function writeLastCheck(timestamp: number): void {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(LAST_CHECK_KEY, String(timestamp))
+    }
+  }
+
+  if (typeof sessionStorage !== 'undefined') {
+    if (sessionStorage.getItem(DISMISSED_KEY) === 'true') {
+      isDismissed.value = true
+    }
+  }
+
+  async function fetchLatestRelease(): Promise<{ html_url: string; tag_name: string } | null> {
+    const response = await fetch(RELEASES_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+    if (!response.ok) return null
+    return response.json()
+  }
+
+  function clearUpToDateTimer(): void {
+    if (upToDateTimeoutId !== undefined) {
+      clearTimeout(upToDateTimeoutId)
+      upToDateTimeoutId = undefined
+    }
+  }
+
+  async function checkForUpdate(): Promise<void> {
+    if (!desktop.value.isDesktop) return
+    if (typeof __APP_VERSION__ === 'undefined') return
+    if (isDismissed.value) return
+
+    try {
+      const data = await fetchLatestRelease()
+      if (!data) return
+
+      const latestVersion = data.tag_name
+
+      if (compareSemver(__APP_VERSION__, latestVersion) < 0) {
+        updateInfo.value = {
+          currentVersion: __APP_VERSION__,
+          latestVersion,
+          releaseUrl: data.html_url,
+        }
+      } else {
+        updateInfo.value = null
+      }
+
+      writeLastCheck(Date.now())
+    } catch {
+      // Update checks should never disrupt the user
+    }
+  }
+
+  async function checkNow(): Promise<void> {
+    if (!desktop.value.isDesktop) return
+    if (typeof __APP_VERSION__ === 'undefined') return
+    if (manualCheckStatus.value === 'checking') return
+
+    clearUpToDateTimer()
+    manualCheckStatus.value = 'checking'
+
+    // Reset dismissed state so banner can reappear if update found
+    isDismissed.value = false
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem(DISMISSED_KEY)
+    }
+
+    try {
+      const data = await fetchLatestRelease()
+      if (!data) {
+        manualCheckStatus.value = 'idle'
+        return
+      }
+
+      const latestVersion = data.tag_name
+
+      writeLastCheck(Date.now())
+
+      if (compareSemver(__APP_VERSION__, latestVersion) < 0) {
+        updateInfo.value = {
+          currentVersion: __APP_VERSION__,
+          latestVersion,
+          releaseUrl: data.html_url,
+        }
+        manualCheckStatus.value = 'idle'
+      } else {
+        updateInfo.value = null
+        manualCheckStatus.value = 'up-to-date'
+        upToDateTimeoutId = setTimeout(() => {
+          manualCheckStatus.value = 'idle'
+        }, UP_TO_DATE_DISPLAY_MS)
+      }
+    } catch {
+      manualCheckStatus.value = 'idle'
+    }
+  }
+
+  function dismiss(): void {
+    isDismissed.value = true
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(DISMISSED_KEY, 'true')
+    }
+  }
+
+  function download(): void {
+    if (updateInfo.value) {
+      void desktop.value.shell.openExternal(updateInfo.value.releaseUrl)
+    }
+  }
+
+  function startChecking(): void {
+    const elapsed = Date.now() - readLastCheck()
+    const remaining = Math.max(0, CHECK_INTERVAL_MS - elapsed)
+    const firstCheck = remaining === 0 ? INITIAL_DELAY_MS : remaining + INITIAL_DELAY_MS
+
+    timeoutId = setTimeout(() => {
+      void checkForUpdate()
+    }, firstCheck)
+
+    intervalId = setInterval(() => {
+      void checkForUpdate()
+    }, CHECK_INTERVAL_MS)
+  }
+
+  function stopChecking(): void {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+      timeoutId = undefined
+    }
+    if (intervalId !== undefined) {
+      clearInterval(intervalId)
+      intervalId = undefined
+    }
+    clearUpToDateTimer()
+  }
+
+  const updateAvailable = computed(() => updateInfo.value !== null && !isDismissed.value)
+  const showBanner = computed(
+    () => updateAvailable.value || manualCheckStatus.value === 'up-to-date',
+  )
+
+  return {
+    checkNow,
+    dismiss,
+    download,
+    manualCheckStatus: readonly(manualCheckStatus),
+    showBanner,
+    startChecking,
+    stopChecking,
+    updateAvailable,
+    updateInfo: readonly(updateInfo),
+  }
+}

--- a/packages/app/src/features/markdown/components/UpdateBanner.vue
+++ b/packages/app/src/features/markdown/components/UpdateBanner.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+interface Props {
+  currentVersion?: string
+  latestVersion?: string
+  status: 'up-to-date' | 'update-available'
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  dismiss: []
+  download: []
+}>()
+
+const normalizeVersion = (v?: string) => v?.replace(/^v/, '')
+</script>
+
+<template>
+  <div class="update-banner" role="status">
+    <div class="update-banner__content">
+      <!-- Update available icon -->
+      <svg
+        v-if="status === 'update-available'"
+        class="update-banner__icon"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <circle cx="8" cy="8" r="6.5" />
+        <path d="M8 5v6M5.5 8.5L8 11l2.5-2.5" />
+      </svg>
+
+      <!-- Up to date icon -->
+      <svg
+        v-else
+        class="update-banner__icon"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <circle cx="8" cy="8" r="6.5" />
+        <path d="M5.5 8l2 2 3.5-3.5" />
+      </svg>
+
+      <span class="update-banner__text">
+        {{ status === 'update-available' ? 'Update available' : "You're up to date" }}
+      </span>
+
+      <span
+        v-if="status === 'update-available' && currentVersion && latestVersion"
+        class="update-banner__versions"
+      >
+        v{{ normalizeVersion(currentVersion) }} &rarr; v{{ normalizeVersion(latestVersion) }}
+      </span>
+
+      <button
+        v-if="status === 'update-available'"
+        class="update-banner__download-btn"
+        type="button"
+        @click="emit('download')"
+      >
+        Download
+      </button>
+    </div>
+
+    <button
+      v-if="status === 'update-available'"
+      class="update-banner__close-btn"
+      type="button"
+      aria-label="Dismiss update notification"
+      @click="emit('dismiss')"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <path d="M4 4l8 8M12 4l-8 8" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.update-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px var(--app-gutter);
+  background: var(--accent-light);
+  border-bottom: 1px solid var(--accent-mid);
+  flex-shrink: 0;
+}
+
+.update-banner__content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.update-banner__icon {
+  width: 15px;
+  height: 15px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.update-banner__text {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent);
+}
+
+.update-banner__versions {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.update-banner__download-btn {
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.update-banner__download-btn:hover {
+  opacity: 0.85;
+}
+
+.update-banner__download-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.update-banner__close-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.update-banner__close-btn:hover {
+  color: var(--text);
+  background: var(--panel);
+}
+
+.update-banner__close-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.update-banner__close-btn svg {
+  width: 12px;
+  height: 12px;
+}
+</style>

--- a/packages/app/src/utils/__tests__/semver.spec.ts
+++ b/packages/app/src/utils/__tests__/semver.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareSemver } from '../semver'
+
+describe('compareSemver', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0)
+    expect(compareSemver('0.2.0', '0.2.0')).toBe(0)
+  })
+
+  it('returns -1 when a is less than b (major)', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1)
+  })
+
+  it('returns -1 when a is less than b (minor)', () => {
+    expect(compareSemver('0.1.0', '0.2.0')).toBe(-1)
+  })
+
+  it('returns -1 when a is less than b (patch)', () => {
+    expect(compareSemver('0.2.0', '0.2.1')).toBe(-1)
+  })
+
+  it('returns 1 when a is greater than b', () => {
+    expect(compareSemver('2.0.0', '1.0.0')).toBe(1)
+    expect(compareSemver('0.3.0', '0.2.0')).toBe(1)
+    expect(compareSemver('0.2.1', '0.2.0')).toBe(1)
+  })
+
+  it('strips v prefix before comparing', () => {
+    expect(compareSemver('v0.2.0', 'v0.3.0')).toBe(-1)
+    expect(compareSemver('0.2.0', 'v0.2.0')).toBe(0)
+    expect(compareSemver('v1.0.0', '0.9.0')).toBe(1)
+  })
+})

--- a/packages/app/src/utils/semver.ts
+++ b/packages/app/src/utils/semver.ts
@@ -1,0 +1,10 @@
+import semver from 'semver'
+
+/**
+ * Compare two semver version strings.
+ *
+ * @returns -1 if a < b, 0 if equal, 1 if a > b
+ */
+export function compareSemver(a: string, b: string): number {
+  return semver.compare(a, b)
+}

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -7,11 +7,13 @@ import type { Example, Theme, ViewMode } from '@/features/markdown/types'
 
 import { useDesktop } from '@/composables/useDesktop'
 import { useThemeTransition } from '@/composables/useThemeTransition'
+import { useUpdateChecker } from '@/composables/useUpdateChecker'
 import EditorPane from '@/features/markdown/components/EditorPane.vue'
 import ExamplesModal from '@/features/markdown/components/ExamplesModal.vue'
 import PreviewPane from '@/features/markdown/components/PreviewPane.vue'
 import StatusBar from '@/features/markdown/components/StatusBar.vue'
 import Toolbar from '@/features/markdown/components/Toolbar.vue'
+import UpdateBanner from '@/features/markdown/components/UpdateBanner.vue'
 import { useDocumentSession } from '@/features/markdown/composables/useDocumentSession'
 import { useMarkdownEditor } from '@/features/markdown/composables/useMarkdownEditor'
 
@@ -61,7 +63,21 @@ interface ThemeChangeRequest {
 }
 
 const { transitionTheme } = useThemeTransition()
+const {
+  checkNow,
+  dismiss: dismissUpdateBanner,
+  download: downloadUpdate,
+  showBanner,
+  startChecking: startUpdateChecks,
+  stopChecking: stopUpdateChecks,
+  updateAvailable,
+  updateInfo,
+} = useUpdateChecker()
 const mobileBreakpoint = 700
+
+const bannerStatus = computed(() =>
+  updateAvailable.value ? ('update-available' as const) : ('up-to-date' as const),
+)
 
 // Local state
 const isExamplesModalOpen = shallowRef(false)
@@ -188,10 +204,15 @@ function syncViewport(): void {
 onMounted(() => {
   syncViewport()
   window.addEventListener('resize', syncViewport)
+  startUpdateChecks()
 
   const onAppCommand = desktop.value?.commands?.onAppCommand
   if (onAppCommand) {
     removeDesktopCommandListener = onAppCommand((command: AppCommand) => {
+      if (command === 'update:check') {
+        void checkNow()
+        return
+      }
       void handleAppCommand(command).catch((err: unknown) => {
         console.error('Failed to handle desktop app command:', err)
       })
@@ -204,6 +225,7 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('resize', syncViewport)
   removeDesktopCommandListener()
+  stopUpdateChecks()
 })
 
 watch(
@@ -234,6 +256,17 @@ watch(
       @copy="copyContent"
       @save-document="saveDocument"
     />
+
+    <Transition name="banner-slide">
+      <UpdateBanner
+        v-if="showBanner"
+        :status="bannerStatus"
+        :current-version="updateInfo?.currentVersion"
+        :latest-version="updateInfo?.latestVersion"
+        @dismiss="dismissUpdateBanner"
+        @download="downloadUpdate"
+      />
+    </Transition>
 
     <main class="main-content">
       <EditorPane
@@ -313,5 +346,29 @@ watch(
   .markdown-studio :deep(.preview-pane) {
     min-height: 0;
   }
+}
+
+.banner-slide-enter-active,
+.banner-slide-leave-active {
+  transition:
+    max-height 0.3s ease,
+    opacity 0.3s ease,
+    padding-top 0.3s ease,
+    padding-bottom 0.3s ease;
+  overflow: hidden;
+}
+
+.banner-slide-enter-from,
+.banner-slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.banner-slide-enter-to,
+.banner-slide-leave-from {
+  max-height: 60px;
+  opacity: 1;
 }
 </style>

--- a/packages/desktop-contract/src/types.ts
+++ b/packages/desktop-contract/src/types.ts
@@ -1,4 +1,4 @@
-export type AppCommand = 'document:open' | 'document:save' | 'document:saveAs'
+export type AppCommand = 'document:open' | 'document:save' | 'document:saveAs' | 'update:check'
 
 export interface DesktopApi {
   commands: DesktopCommandsApi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.0.2(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
@@ -65,6 +68,9 @@ importers:
       oxlint:
         specifier: ~1.56.0
         version: 1.56.0
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
       start-server-and-test:
         specifier: ^2.1.5
         version: 2.1.5
@@ -1404,6 +1410,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -5849,6 +5858,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.12.0
+
+  '@types/semver@7.7.1': {}
 
   '@types/sinonjs__fake-timers@8.1.1': {}
 


### PR DESCRIPTION
## Summary

Adds an update checker feature that uses semver to detect and notify users of available application updates. The update banner appears in the UI when a new version is available, with support for checking against GitHub releases.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [ ] Manual testing notes:

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [ ] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [ ] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
