### PR TITLE
fix(ci): remove redundant NODE_AUTH_TOKEN from publish step

### DIFF
--- a/.changeset/fix-publish-workflow.md
+++ b/.changeset/fix-publish-workflow.md
@@ -1,0 +1,5 @@
+---
+"markdown-studio": patch
+---
+
+Fix npm publish workflow by removing redundant NODE_AUTH_TOKEN environment variable

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -73,8 +73,6 @@ jobs:
         if: ${{ !inputs.dry_run }}
         working-directory: packages/cli
         run: npm publish --provenance --tag "${{ steps.publish_meta.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Ensure publish tag exists
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

Removes redundant NODE_AUTH_TOKEN environment variable from the npm publish step in the release workflow. The authentication token is already configured at the job level, making this explicit env declaration unnecessary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: This is a CI workflow change that affects the release process. The workflow will be validated when the next release is triggered.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
- [ ] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
