### PR TITLE
fix(desktop): normalize desktop-v prefix in semver comparison

### DIFF
--- a/.changeset/normalize-desktop-semver.md
+++ b/.changeset/normalize-desktop-semver.md
@@ -1,0 +1,5 @@
+---
+'@markdown-studio/desktop': patch
+---
+
+Normalize desktop-v prefix in semver comparison for consistent desktop release versioning

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 - When running a specific single test file in Vitest, use the `pnpm exec vitest run` command; e.g.: `pnpm exec vitest run packages/app/src/__tests__/App.spec.ts`.
 - Do not use outdated or redundant scripts when a repo-specific command already exists.
 
+## Issue and PR Templates
+
+- Use the appropriate issue or PR template when creating a new issue or PR located in the `.github` directory.
+- If the template doesn't fit, update it to match the new use case.
+
 ## Project Snapshot
 
 Markdown Studio is a Vue 3 + Electron Markdown editor with live preview, Mermaid diagram support, and a split web/desktop experience. The repo is intentionally lightweight and still evolving, so changes that improve long-term clarity, maintainability, and UI quality are welcome.

--- a/packages/app/src/utils/__tests__/semver.spec.ts
+++ b/packages/app/src/utils/__tests__/semver.spec.ts
@@ -31,4 +31,21 @@ describe('compareSemver', () => {
     expect(compareSemver('0.2.0', 'v0.2.0')).toBe(0)
     expect(compareSemver('v1.0.0', '0.9.0')).toBe(1)
   })
+
+  it('strips desktop-v prefix before comparing', () => {
+    expect(compareSemver('desktop-v0.2.0', 'desktop-v0.3.0')).toBe(-1)
+    expect(compareSemver('desktop-v0.2.0', 'desktop-v0.2.0')).toBe(0)
+    expect(compareSemver('desktop-v1.0.0', 'desktop-v0.9.0')).toBe(1)
+  })
+
+  it('compares mixed tag formats', () => {
+    expect(compareSemver('desktop-v1.2.3', '1.2.3')).toBe(0)
+    expect(compareSemver('desktop-v1.2.3', 'v1.2.4')).toBe(-1)
+    expect(compareSemver('1.3.0', 'desktop-v1.2.0')).toBe(1)
+  })
+
+  it('throws on invalid version strings', () => {
+    expect(() => compareSemver('not-a-version', '1.0.0')).toThrow('Invalid semver')
+    expect(() => compareSemver('1.0.0', '')).toThrow('Invalid semver')
+  })
 })

--- a/packages/app/src/utils/semver.ts
+++ b/packages/app/src/utils/semver.ts
@@ -3,8 +3,24 @@ import semver from 'semver'
 /**
  * Compare two semver version strings.
  *
+ * Accepts plain versions (1.2.3), v-prefixed (v1.2.3), and
+ * tagged formats like desktop-v1.2.3.
+ *
  * @returns -1 if a < b, 0 if equal, 1 if a > b
  */
 export function compareSemver(a: string, b: string): number {
-  return semver.compare(a, b)
+  return semver.compare(coerce(a), coerce(b))
+}
+
+/**
+ * Normalize a version string by extracting the semver portion.
+ * Handles plain versions (1.2.3), v-prefix (v1.2.3), and
+ * tagged formats like desktop-v1.2.3.
+ */
+function coerce(version: string): string {
+  const coerced = semver.coerce(version)
+  if (!coerced) {
+    throw new Error(`Invalid semver: "${version}"`)
+  }
+  return coerced.version
 }


### PR DESCRIPTION
## Summary

Normalize `desktop-v` prefix handling in semver comparison to ensure consistent version comparison for desktop releases. This adds support for stripping the `desktop-v` prefix before comparing versions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [ ] Manual testing notes:

## Related Issue

Fixes #21

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [ ] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [ ] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)