### PR TITLE
ci(workflows): remove title param and add contributors section to release notes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -74,7 +74,6 @@ jobs:
           --ref "${{ steps.publish_meta.outputs.sha }}"
           --tag-pattern "npm-v*"
           --version "${{ steps.publish_meta.outputs.version }}"
-          --title "markdown-studio npm v${{ steps.publish_meta.outputs.version }}"
           --output "${{ runner.temp }}/npm-release-notes.md"
 
       - name: Build npm package

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -72,7 +72,6 @@ jobs:
           --ref "${{ steps.release_meta.outputs.sha }}"
           --tag-pattern "desktop-v*"
           --version "${{ steps.release_meta.outputs.version }}"
-          --title "Markdown Studio Desktop v${{ steps.release_meta.outputs.version }}"
           --output "${{ runner.temp }}/desktop-release-notes.md"
 
       - name: Format

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -66,17 +66,22 @@ export async function generateReleaseNotes({
   outputPath,
   ref,
   tagPattern,
-  title,
   version,
 }) {
   const changelogSource = await readFile(changelogPath, 'utf8')
   const previousTag = await findPreviousArtifactTag({ currentTag, ref, tagPattern })
   const commitSubjects = await getCommitSubjectsSinceTag({ previousTag, ref })
+  const contributors = await getContributors({ previousTag, ref })
+  const changelogNotes = renderReleaseNotes({ changelogSource, version })
   const commitsByScope = renderCommitsByScopeSection(commitSubjects)
-  const changelogNotes = renderReleaseNotes({ changelogSource, title, version })
+  const contributorsSection = renderContributorsSection(contributors)
 
   await mkdir(path.dirname(outputPath), { recursive: true })
-  await writeFile(outputPath, `${[changelogNotes, commitsByScope].join('\n\n')}\n`, 'utf8')
+  await writeFile(
+    outputPath,
+    `${[changelogNotes, commitsByScope, contributorsSection].join('\n\n')}\n`,
+    'utf8',
+  )
 }
 
 export async function getCommitSubjectsSinceTag({ previousTag, ref }) {
@@ -87,6 +92,34 @@ export async function getCommitSubjectsSinceTag({ previousTag, ref }) {
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
+}
+
+export async function getContributors({ previousTag, ref }) {
+  const revisionRange = previousTag ? `${previousTag}..${ref}` : ref
+  const stdout = await runGit(['log', '--format=%aN%x00%aE', revisionRange])
+
+  const authors = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [name, email] = line.split('\0')
+      return { email, name }
+    })
+
+  const seen = new Set()
+  const uniqueAuthors = []
+  for (const author of authors) {
+    if (!seen.has(author.email)) {
+      seen.add(author.email)
+      uniqueAuthors.push(author)
+    }
+  }
+
+  return uniqueAuthors.map((author) => ({
+    ...author,
+    username: resolveGitHubUsername(author.email),
+  }))
 }
 
 export function groupCommitSubjectsByScope(subjects) {
@@ -153,10 +186,30 @@ export function renderCommitsByScopeSection(subjects) {
   return lines.join('\n')
 }
 
-export function renderReleaseNotes({ changelogSource, title, version }) {
-  const section = extractChangelogSection(changelogSource, version)
+export function renderContributorsSection(contributors) {
+  if (contributors.length === 0) {
+    return '## Contributors\n\n_No contributors found for this release range._'
+  }
 
-  return [`# ${title}`, '', section].join('\n')
+  const lines = ['## Contributors']
+  for (const c of contributors) {
+    if (c.username) {
+      lines.push(`- [@${c.username}](https://github.com/${c.username}) (${c.name})`)
+    } else {
+      lines.push(`- ${c.name}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function renderReleaseNotes({ changelogSource, version }) {
+  return extractChangelogSection(changelogSource, version)
+}
+
+export function resolveGitHubUsername(email) {
+  const match = email.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)
+  return match ? match[1] : null
 }
 
 export function shouldIncludeCommitSubject(subject) {
@@ -184,7 +237,6 @@ function parseArgs(argv) {
     output: '',
     ref: 'HEAD',
     tagPattern: '',
-    title: '',
     version: '',
   }
 
@@ -222,12 +274,6 @@ function parseArgs(argv) {
       continue
     }
 
-    if (arg === '--title') {
-      args.title = value ?? ''
-      index += 1
-      continue
-    }
-
     if (arg === '--version') {
       args.version = value ?? ''
       index += 1
@@ -241,11 +287,10 @@ function parseArgs(argv) {
     !args.output ||
     !args.ref ||
     !args.tagPattern ||
-    !args.title ||
     !args.version
   ) {
     throw new Error(
-      'Usage: node ./scripts/generate-release-notes.mjs --changelog <path> --version <version> --title <title> --current-tag <tag> --tag-pattern <pattern> --ref <git-ref> --output <path>',
+      'Usage: node ./scripts/generate-release-notes.mjs --changelog <path> --version <version> --current-tag <tag> --tag-pattern <pattern> --ref <git-ref> --output <path>',
     )
   }
 
@@ -258,7 +303,7 @@ async function runGit(args) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const { changelog, currentTag, output, ref, tagPattern, title, version } = parseArgs(
+  const { changelog, currentTag, output, ref, tagPattern, version } = parseArgs(
     process.argv.slice(2),
   )
   const changelogPath = path.resolve(rootDir, changelog)
@@ -270,7 +315,6 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     outputPath,
     ref,
     tagPattern,
-    title,
     version,
   })
 }

--- a/scripts/generate-release-notes.spec.mjs
+++ b/scripts/generate-release-notes.spec.mjs
@@ -6,7 +6,9 @@ import {
   groupCommitSubjectsByScope,
   parseConventionalCommitSubject,
   renderCommitsByScopeSection,
+  renderContributorsSection,
   renderReleaseNotes,
+  resolveGitHubUsername,
   shouldIncludeCommitSubject,
 } from './generate-release-notes.mjs'
 
@@ -40,7 +42,7 @@ describe('extractChangelogSection', () => {
 })
 
 describe('renderReleaseNotes', () => {
-  it('renders a markdown title followed by the changelog section', () => {
+  it('renders the changelog section without a title heading', () => {
     const releaseNotes = renderReleaseNotes({
       changelogSource: `# package
 
@@ -50,13 +52,10 @@ describe('renderReleaseNotes', () => {
 
 - Keep npm notes artifact-specific
 `,
-      title: 'markdown-studio npm v0.3.0',
       version: '0.3.0',
     })
 
-    expect(releaseNotes).toBe(`# markdown-studio npm v0.3.0
-
-### Patch Changes
+    expect(releaseNotes).toBe(`### Patch Changes
 
 - Keep npm notes artifact-specific`)
   })
@@ -221,5 +220,55 @@ describe('renderCommitsByScopeSection', () => {
     expect(renderCommitsByScopeSection([])).toBe(`## Commits by scope
 
 _No matching commits found for this release range._`)
+  })
+})
+
+describe('resolveGitHubUsername', () => {
+  it('extracts the username from the new-style noreply email', () => {
+    expect(resolveGitHubUsername('41898282+github-actions[bot]@users.noreply.github.com')).toBe(
+      'github-actions[bot]',
+    )
+  })
+
+  it('extracts the username from the old-style noreply email', () => {
+    expect(resolveGitHubUsername('octocat@users.noreply.github.com')).toBe('octocat')
+  })
+
+  it('returns null for regular email addresses', () => {
+    expect(resolveGitHubUsername('user@example.com')).toBeNull()
+  })
+})
+
+describe('renderContributorsSection', () => {
+  it('renders contributors with GitHub usernames as clickable links', () => {
+    expect(
+      renderContributorsSection([
+        {
+          email: '41898282+github-actions[bot]@users.noreply.github.com',
+          name: 'GitHub Actions',
+          username: 'github-actions[bot]',
+        },
+        {
+          email: '123456+theoklitosBam7@users.noreply.github.com',
+          name: 'Theoklitos Bampouris',
+          username: 'theoklitosBam7',
+        },
+      ]),
+    ).toBe(`## Contributors
+- [@github-actions[bot]](https://github.com/github-actions[bot]) (GitHub Actions)
+- [@theoklitosBam7](https://github.com/theoklitosBam7) (Theoklitos Bampouris)`)
+  })
+
+  it('renders contributors without a username as plain names', () => {
+    expect(
+      renderContributorsSection([{ email: 'john@example.com', name: 'John Doe', username: null }]),
+    ).toBe(`## Contributors
+- John Doe`)
+  })
+
+  it('renders an empty-state message when no contributors are available', () => {
+    expect(renderContributorsSection([])).toBe(`## Contributors
+
+_No contributors found for this release range._`)
   })
 })


### PR DESCRIPTION
## Summary

Remove the unused `--title` parameter from the release notes generation script and workflows, and add a Contributors section to the generated release notes output.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified release notes script works without --title flag

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [ ] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)