### PR TITLE
fix(app): close export menu when clicking outside

### DIFF
--- a/.changeset/fix-export-menu-click-outside.md
+++ b/.changeset/fix-export-menu-click-outside.md
@@ -1,0 +1,6 @@
+---
+'@markdown-studio/desktop': patch
+'markdown-studio': patch
+---
+
+Fix export menu not closing when clicking outside

--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -395,4 +395,15 @@ describe('Markdown Studio responsive shell', () => {
     cy.get('.preview-pane').should('be.visible')
     cy.get('.editor-pane').should('not.be.visible')
   })
+
+  it('closes the export menu when clicking outside of it', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/')
+
+    openExportMenu()
+    cy.get('.export-menu__popover').should('be.visible')
+
+    cy.get('textarea').click('topLeft')
+    cy.get('.export-menu__popover').should('not.be.visible')
+  })
 })

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { shallowRef, useTemplateRef } from 'vue'
+import { onMounted, onUnmounted, shallowRef, useTemplateRef } from 'vue'
 
 import ThemeToggle from '@/components/base/ThemeToggle.vue'
 import ToolbarButton from '@/components/base/ToolbarButton.vue'
@@ -95,9 +95,23 @@ function handleExportMenuToggle(event: Event): void {
   }
 }
 
+function handleOutsideClick(event: MouseEvent): void {
+  if (!exportMenuRef.value?.contains(event.target as Node)) {
+    closeExportMenu()
+  }
+}
+
 function toggleExportMenu(nextOpen: boolean): void {
   isExportMenuOpen.value = nextOpen
 }
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick, true)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleOutsideClick, true)
+})
 </script>
 
 <template>

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -1,21 +1,34 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import Toolbar from '../Toolbar.vue'
 
+function mountToolbar(overrides: Record<string, unknown> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  return mount(Toolbar, {
+    attachTo: container,
+    props: {
+      availableModes: ['editor', 'split', 'preview'],
+      canOpenDocuments: true,
+      canSaveDocuments: true,
+      isCopied: false,
+      isMobile: false,
+      theme: 'light',
+      viewMode: 'split',
+      ...overrides,
+    },
+  })
+}
+
 describe('Toolbar', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('renders desktop controls with split mode available', () => {
-    const wrapper = mount(Toolbar, {
-      props: {
-        availableModes: ['editor', 'split', 'preview'],
-        canOpenDocuments: true,
-        canSaveDocuments: true,
-        isCopied: false,
-        isMobile: false,
-        theme: 'light',
-        viewMode: 'split',
-      },
-    })
+    const wrapper = mountToolbar()
 
     expect(wrapper.find('.toolbar__desktop-controls').exists()).toBe(true)
     expect(wrapper.find('.toolbar__mobile-controls').exists()).toBe(false)
@@ -26,16 +39,10 @@ describe('Toolbar', () => {
   })
 
   it('renders reachable mobile controls without split mode', () => {
-    const wrapper = mount(Toolbar, {
-      props: {
-        availableModes: ['editor', 'preview'],
-        canOpenDocuments: true,
-        canSaveDocuments: true,
-        isCopied: false,
-        isMobile: true,
-        theme: 'light',
-        viewMode: 'editor',
-      },
+    const wrapper = mountToolbar({
+      availableModes: ['editor', 'preview'],
+      isMobile: true,
+      viewMode: 'editor',
     })
 
     expect(wrapper.find('.toolbar__mobile-controls').exists()).toBe(true)
@@ -48,19 +55,48 @@ describe('Toolbar', () => {
   })
 
   it('hides open and save when document actions are unavailable', () => {
-    const wrapper = mount(Toolbar, {
-      props: {
-        availableModes: ['editor', 'preview'],
-        canOpenDocuments: false,
-        canSaveDocuments: false,
-        isCopied: false,
-        isMobile: false,
-        theme: 'light',
-        viewMode: 'editor',
-      },
+    const wrapper = mountToolbar({
+      availableModes: ['editor', 'preview'],
+      canOpenDocuments: false,
+      canSaveDocuments: false,
+      viewMode: 'editor',
     })
 
     expect(wrapper.text()).not.toContain('Open')
     expect(wrapper.text()).not.toContain('Save')
+  })
+
+  describe('export menu', () => {
+    it('closes the export menu when clicking outside', () => {
+      const wrapper = mountToolbar()
+
+      const summary = wrapper.get('.export-menu summary')
+      summary.trigger('click')
+      expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(true)
+
+      document.body.click()
+      expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(false)
+    })
+
+    it('keeps the export menu open when clicking inside the popover', () => {
+      const wrapper = mountToolbar()
+
+      const summary = wrapper.get('.export-menu summary')
+      summary.trigger('click')
+      expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(true)
+
+      wrapper.get('.export-menu__item').trigger('click')
+      expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(false)
+    })
+
+    it('removes the click-outside listener when the component is unmounted', () => {
+      const wrapper = mountToolbar()
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+      wrapper.unmount()
+
+      expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function), true)
+      removeSpy.mockRestore()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Add click-outside handler to close the export menu when the user clicks outside the menu, fixing the standard dropdown behavior described in issue #26.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [x] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Click Export button, then click outside menu - menu should close

## Related Issue

Fixes #26

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)