### PR TITLE
fix(common): hide export popover when menu is closed

### DIFF
--- a/.changeset/export-popover-visibility-fix.md
+++ b/.changeset/export-popover-visibility-fix.md
@@ -1,0 +1,9 @@
+---
+'markdown-studio': patch
+'@markdown-studio/desktop': patch
+---
+
+Hide export popover when menu is closed
+
+- Add CSS rule to prevent the export popover from being visible when the details element is not in open state.
+- This ensures the popover is properly hidden during transitions and when closed via outside click.

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -353,6 +353,10 @@ onUnmounted(() => {
   z-index: 20;
 }
 
+.export-menu:not([open]) .export-menu__popover {
+  display: none;
+}
+
 .export-menu__item {
   appearance: none;
   border: none;

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -73,9 +73,11 @@ describe('Toolbar', () => {
       const summary = wrapper.get('.export-menu summary')
       summary.trigger('click')
       expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(true)
+      expect(wrapper.get('.export-menu__popover').isVisible()).toBe(true)
 
       document.body.click()
       expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(false)
+      expect(wrapper.get('.export-menu__popover').isVisible()).toBe(false)
     })
 
     it('keeps the export menu open when clicking inside the popover', () => {


### PR DESCRIPTION
## Summary

Fixes a CSS visibility issue where the export popover could remain visible when the export menu is closed. This ensures the popover is properly hidden by adding a CSS rule that sets `display: none` when the details element is not in the open state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [x] E2E tests pass: `pnpm test:e2e` (if applicable)
- [ ] Manual testing notes:

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
