### PR TITLE
refactor(ci): exclude landing-page and ci scopes from release notes

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -74,18 +74,6 @@ jobs:
           --version "${{ steps.release_meta.outputs.version }}"
           --output "${{ runner.temp }}/desktop-release-notes.md"
 
-      - name: Format
-        run: pnpm format:check
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Type check
-        run: pnpm type-check
-
-      - name: Run unit tests
-        run: pnpm test:unit
-
       - name: Build desktop artifacts
         run: pnpm dist:mac
 

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - a112de5: Add find and replace functionality to the editor
-
   - Add FindReplaceBar component with search input and replace controls
   - Add MatchOverlay component for highlighting search matches in the editor
   - Implement useFindReplace composable for managing search state and operations
@@ -19,7 +18,6 @@
 ### Patch Changes
 
 - 33eece6: Hide export popover when menu is closed
-
   - Add CSS rule to prevent the export popover from being visible when the details element is not in open state.
   - This ensures the popover is properly hidden during transitions and when closed via outside click.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - a112de5: Add find and replace functionality to the editor
-
   - Add FindReplaceBar component with search input and replace controls
   - Add MatchOverlay component for highlighting search matches in the editor
   - Implement useFindReplace composable for managing search state and operations
@@ -19,7 +18,6 @@
 ### Patch Changes
 
 - 33eece6: Hide export popover when menu is closed
-
   - Add CSS rule to prevent the export popover from being visible when the details element is not in open state.
   - This ensures the popover is properly hidden during transitions and when closed via outside click.
 

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -15,14 +15,12 @@ export const allowedReleaseNoteScopes = [
   'common',
   'desktop',
   'electron',
-  'export',
   'landing-page',
   'markdown',
 ]
 
 const releaseNoteScopeAliases = new Map([
   ['markdown-editor', 'markdown'],
-  ['useDocumentActions', 'markdown'],
   ['workflows', 'ci'],
 ])
 
@@ -216,7 +214,10 @@ export function resolveGitHubUsername(email) {
 export function shouldIncludeCommitSubject(subject) {
   const entry = parseConventionalCommitSubject(subject)
 
-  return !(entry.type === 'chore' && entry.rawScope === 'release')
+  if (entry.type === 'chore' && entry.rawScope === 'release') return false
+  if (entry.scope === 'landing-page' || entry.scope === 'ci') return false
+
+  return true
 }
 
 function normalizeReleaseNoteScope(scope) {


### PR DESCRIPTION
## Summary

Update release notes generation to exclude commits with `landing-page` or `ci` scopes. Also removes redundant quality checks from the desktop release workflow and cleans up extra blank lines in changelogs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verify release notes exclude landing-page and ci commits

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

N/A

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
