### PR TITLE
fix(web): disable PDF export on mobile and installed PWAs

### DIFF
--- a/.changeset/fix-pwa-export-pdf-on-mobile.md
+++ b/.changeset/fix-pwa-export-pdf-on-mobile.md
@@ -1,0 +1,6 @@
+---
+"markdown-studio": patch
+---
+
+Disable PDF export on mobile devices and installed PWAs
+- PDF export functionality is now disabled on mobile devices and installed Progressive Web Apps, with a helpful tooltip explaining that users should use "Export as HTML" as an alternative. This addresses browser limitations with PDF generation on mobile platforms.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "embeddedLanguageFormatting": "auto",
-  "ignorePatterns": [".changeset/**"],
+  "ignorePatterns": [".changeset/**", "**/CHANGELOG.md"],
   "semi": false,
   "singleQuote": true
 }

--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -161,7 +161,15 @@ describe('Markdown Studio responsive shell', () => {
     cy.get('.mobile-action-sheet__action').contains('Copy Markdown').should('be.visible')
     cy.get('.mobile-action-sheet__action').contains('Clear Document').should('be.visible')
     cy.get('.mobile-action-sheet__action').contains('Export as HTML').should('be.visible')
-    cy.get('.mobile-action-sheet__action').contains('Export as PDF').should('be.visible')
+    cy.contains('.mobile-action-sheet__action', 'Export as PDF')
+      .should('be.visible')
+      .and('be.disabled')
+      .within(() => {
+        cy.contains("PDF export isn't available on mobile or installed PWAs yet.").should(
+          'be.visible',
+        )
+        cy.contains('Use Export as HTML instead.').should('be.visible')
+      })
 
     // Close action sheet and switch to preview mode
     cy.get('.mobile-action-sheet__cancel').click()

--- a/packages/app/src/components/base/MobileActionSheet.vue
+++ b/packages/app/src/components/base/MobileActionSheet.vue
@@ -3,6 +3,8 @@ import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
 
 interface ActionItem {
   action: () => void
+  description?: string
+  disabled?: boolean
   icon?: string
   label: string
   variant?: 'danger' | 'default' | 'primary'
@@ -62,6 +64,14 @@ function handleBackdropClick(event: MouseEvent): void {
   if (event.target === event.currentTarget) {
     close()
   }
+}
+
+function handleItemClick(item: ActionItem): void {
+  if (item.disabled) {
+    return
+  }
+
+  handleAction(item.action)
 }
 
 function handleKeydown(event: KeyboardEvent): void {
@@ -154,15 +164,24 @@ onUnmounted(() => {
               v-for="(item, index) in actions"
               :key="index"
               class="mobile-action-sheet__action"
-              :class="`mobile-action-sheet__action--${item.variant || 'default'}`"
+              :class="[
+                `mobile-action-sheet__action--${item.variant || 'default'}`,
+                { 'mobile-action-sheet__action--disabled': item.disabled },
+              ]"
+              :disabled="item.disabled"
               role="menuitem"
               type="button"
-              @click="handleAction(item.action)"
+              @click="handleItemClick(item)"
             >
               <span v-if="item.icon" class="mobile-action-sheet__icon" aria-hidden="true">
                 {{ item.icon }}
               </span>
-              <span class="mobile-action-sheet__label">{{ item.label }}</span>
+              <span class="mobile-action-sheet__content">
+                <span class="mobile-action-sheet__label">{{ item.label }}</span>
+                <span v-if="item.description" class="mobile-action-sheet__description">
+                  {{ item.description }}
+                </span>
+              </span>
             </button>
           </div>
 
@@ -242,7 +261,7 @@ onUnmounted(() => {
 
 .mobile-action-sheet__action {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
   padding: 14px 16px;
   background: var(--surface);
@@ -260,6 +279,18 @@ onUnmounted(() => {
   background: var(--panel);
 }
 
+.mobile-action-sheet__action:disabled {
+  cursor: not-allowed;
+}
+
+.mobile-action-sheet__action--disabled {
+  color: color-mix(in srgb, var(--text) 55%, transparent);
+}
+
+.mobile-action-sheet__action--disabled:hover {
+  background: var(--surface);
+}
+
 .mobile-action-sheet__action--danger {
   color: var(--error, #dc2626);
 }
@@ -274,10 +305,26 @@ onUnmounted(() => {
   width: 24px;
   text-align: center;
   flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.mobile-action-sheet__content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .mobile-action-sheet__label {
   flex: 1;
+  text-align: left;
+}
+
+.mobile-action-sheet__description {
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--text) 72%, transparent);
   text-align: left;
 }
 

--- a/packages/app/src/components/base/MobileToolbarActions.vue
+++ b/packages/app/src/components/base/MobileToolbarActions.vue
@@ -12,19 +12,23 @@ import ViewToggle from './ViewToggle.vue'
 
 interface Props {
   availableModes?: ViewMode[]
+  canExportPdf?: boolean
   canInstall?: boolean
   canOpenDocuments?: boolean
   canSaveDocuments?: boolean
   isCopied: boolean
+  pdfExportUnavailableReason?: string
   theme: Theme
   viewMode: ViewMode
 }
 
 const props = withDefaults(defineProps<Props>(), {
   availableModes: () => ['editor', 'preview'],
+  canExportPdf: true,
   canInstall: false,
   canOpenDocuments: false,
   canSaveDocuments: false,
+  pdfExportUnavailableReason: '',
 })
 
 const emit = defineEmits<{
@@ -45,6 +49,8 @@ const isActionSheetOpen = shallowRef(false)
 const secondaryActions = computed(() => {
   const actions: {
     action: () => void
+    description?: string
+    disabled?: boolean
     icon: string
     label: string
     variant?: 'danger' | 'default' | 'primary'
@@ -103,6 +109,8 @@ const secondaryActions = computed(() => {
     },
     {
       action: () => emit('exportPdf'),
+      description: props.canExportPdf ? undefined : props.pdfExportUnavailableReason,
+      disabled: !props.canExportPdf,
       icon: '📑',
       label: 'Export as PDF',
     },

--- a/packages/app/src/components/base/__tests__/MobileActionSheet.spec.ts
+++ b/packages/app/src/components/base/__tests__/MobileActionSheet.spec.ts
@@ -86,6 +86,34 @@ describe('MobileActionSheet', () => {
     expect(saveAction).not.toHaveBeenCalled()
   })
 
+  it('renders disabled actions with helper text and does not call them', async () => {
+    const exportPdf = vi.fn()
+
+    mountSheet({
+      actions: [
+        {
+          action: exportPdf,
+          description: 'PDF export is unavailable on mobile. Use HTML instead.',
+          disabled: true,
+          icon: '📑',
+          label: 'Export as PDF',
+        },
+      ],
+      isOpen: true,
+    })
+
+    const actions = document.querySelectorAll('.mobile-action-sheet__action')
+    expect(actions).toHaveLength(1)
+    expect(actions[0]?.hasAttribute('disabled')).toBe(true)
+    expect(actions[0]?.classList.contains('mobile-action-sheet__action--disabled')).toBe(true)
+    expect(actions[0]?.textContent).toContain('Export as PDF')
+    expect(actions[0]?.textContent).toContain('Use HTML instead')
+
+    await actions[0]?.dispatchEvent(new MouseEvent('click'))
+
+    expect(exportPdf).not.toHaveBeenCalled()
+  })
+
   it('closes when cancel button is clicked', async () => {
     const wrapper = mountSheet({ isOpen: true })
 

--- a/packages/app/src/components/base/__tests__/MobileToolbarActions.spec.ts
+++ b/packages/app/src/components/base/__tests__/MobileToolbarActions.spec.ts
@@ -100,6 +100,24 @@ describe('MobileToolbarActions', () => {
     expect(actionLabels.some((label) => label?.includes('View on GitHub'))).toBe(true)
   })
 
+  it('disables pdf export with guidance when unavailable', async () => {
+    mountToolbar({
+      canExportPdf: false,
+      pdfExportUnavailableReason:
+        "PDF export isn't available on mobile or installed PWAs yet. Use Export as HTML instead.",
+    })
+
+    const menuButton = document.querySelector('button[aria-label="Menu"]')
+    await menuButton?.dispatchEvent(new MouseEvent('click'))
+
+    const actions = document.querySelectorAll('.mobile-action-sheet__action')
+    const pdfAction = Array.from(actions).find((el) => el.textContent?.includes('Export as PDF'))
+
+    expect(pdfAction).not.toBeNull()
+    expect(pdfAction?.hasAttribute('disabled')).toBe(true)
+    expect(pdfAction?.textContent).toContain('Use Export as HTML instead')
+  })
+
   it('emits openDocument when Open action is clicked', async () => {
     const wrapper = mountToolbar({ canOpenDocuments: true })
 

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -11,11 +11,13 @@ import type { Theme, ViewMode } from '../types'
 
 interface Props {
   availableModes?: ViewMode[]
+  canExportPdf?: boolean
   canInstall?: boolean
   canOpenDocuments?: boolean
   canSaveDocuments?: boolean
   isCopied: boolean
   isMobile?: boolean
+  pdfExportUnavailableReason?: string
   theme: Theme
   viewMode: ViewMode
 }
@@ -27,10 +29,12 @@ interface ThemeChangeRequest {
 
 const props = withDefaults(defineProps<Props>(), {
   availableModes: () => ['editor', 'split', 'preview'],
+  canExportPdf: true,
   canInstall: false,
   canOpenDocuments: false,
   canSaveDocuments: false,
   isMobile: false,
+  pdfExportUnavailableReason: '',
 })
 
 const emit = defineEmits<{
@@ -130,10 +134,12 @@ onUnmounted(() => {
     <MobileToolbarActions
       v-if="props.isMobile"
       :available-modes="props.availableModes"
+      :can-export-pdf="props.canExportPdf"
       :can-install="props.canInstall"
       :can-open-documents="props.canOpenDocuments"
       :can-save-documents="props.canSaveDocuments"
       :is-copied="props.isCopied"
+      :pdf-export-unavailable-reason="props.pdfExportUnavailableReason"
       :theme="props.theme"
       :view-mode="props.viewMode"
       @clear="clear"
@@ -226,9 +232,21 @@ onUnmounted(() => {
               <button class="export-menu__item" type="button" role="menuitem" @click="exportHtml">
                 Export HTML
               </button>
-              <button class="export-menu__item" type="button" role="menuitem" @click="exportPdf">
+              <button
+                class="export-menu__item"
+                :disabled="!props.canExportPdf"
+                type="button"
+                role="menuitem"
+                @click="exportPdf"
+              >
                 Export PDF
               </button>
+              <p
+                v-if="!props.canExportPdf && props.pdfExportUnavailableReason"
+                class="export-menu__hint"
+              >
+                {{ props.pdfExportUnavailableReason }}
+              </p>
             </div>
           </details>
         </div>
@@ -419,6 +437,23 @@ onUnmounted(() => {
 
 .export-menu__item:hover {
   background: var(--panel);
+}
+
+.export-menu__item:disabled {
+  cursor: not-allowed;
+  color: color-mix(in srgb, var(--text) 55%, transparent);
+}
+
+.export-menu__item:disabled:hover {
+  background: transparent;
+}
+
+.export-menu__hint {
+  margin: 0;
+  padding: 6px 10px 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--text) 72%, transparent);
 }
 
 .github-link {

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -149,6 +149,20 @@ describe('Toolbar', () => {
       expect(wrapper.find('.export-menu').element.hasAttribute('open')).toBe(false)
     })
 
+    it('shows disabled pdf export guidance when pdf export is unavailable', async () => {
+      const wrapper = mountToolbar({
+        canExportPdf: false,
+        pdfExportUnavailableReason:
+          "PDF export isn't available on mobile or installed PWAs yet. Use Export as HTML instead.",
+      })
+
+      await wrapper.get('.export-menu summary').trigger('click')
+
+      const items = wrapper.findAll('.export-menu__item')
+      expect(items[1]?.attributes('disabled')).toBeDefined()
+      expect(wrapper.get('.export-menu__hint').text()).toContain('Use Export as HTML instead')
+    })
+
     it('removes the click-outside listener when the component is unmounted', () => {
       const wrapper = mountToolbar()
       const removeSpy = vi.spyOn(document, 'removeEventListener')

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
@@ -10,6 +10,7 @@ import { useDocumentExport } from '../useDocumentExport'
 const content = shallowRef('# Export\n\nBody copy')
 const currentPath = shallowRef<null | string>('/tmp/export-notes.md')
 const displayName = shallowRef('export-notes.md')
+const isMobile = shallowRef(false)
 
 const Harness = defineComponent({
   setup() {
@@ -17,6 +18,7 @@ const Harness = defineComponent({
       content,
       currentPath,
       displayName,
+      isMobile,
     })
   },
   template: '<div />',
@@ -43,6 +45,7 @@ describe('useDocumentExport', () => {
     content.value = '# Export\n\nBody copy'
     currentPath.value = '/tmp/export-notes.md'
     displayName.value = 'export-notes.md'
+    isMobile.value = false
     appWindow.desktop = undefined
     window.localStorage.clear()
     vi.clearAllMocks()
@@ -117,6 +120,55 @@ describe('useDocumentExport', () => {
     expect(popupWindow.location.href).toMatch(/^\/export\/print\?job=/)
     expect(popupWindow.name).toContain('"title":"export-notes"')
     expect(window.localStorage.length).toBe(1)
+  })
+
+  it('blocks pdf export on mobile web with a stable reason', async () => {
+    isMobile.value = true
+
+    const router = createRouterForTest()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(Harness, {
+      global: {
+        plugins: [router],
+      },
+    })
+    const openSpy = vi.fn()
+    window.open = openSpy as typeof window.open
+
+    const viewModel = wrapper.vm as unknown as {
+      canExportPdf: boolean
+      exportPdf: () => Promise<void>
+      pdfExportUnavailableReason: string
+    }
+
+    expect(viewModel.canExportPdf).toBe(false)
+    expect(viewModel.pdfExportUnavailableReason).toContain('Export as HTML instead')
+    await expect(viewModel.exportPdf()).rejects.toThrow(
+      "PDF export isn't available on mobile or installed PWAs yet. Use Export as HTML instead.",
+    )
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('allows pdf export on desktop browsers even when PWA is installed', async () => {
+    const router = createRouterForTest()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(Harness, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const viewModel = wrapper.vm as unknown as {
+      canExportPdf: boolean
+      pdfExportUnavailableReason: string
+    }
+
+    expect(viewModel.canExportPdf).toBe(true)
+    expect(viewModel.pdfExportUnavailableReason).toBe('')
   })
 
   it('delegates exports to the desktop bridge when available', async () => {

--- a/packages/app/src/features/markdown/composables/useDocumentExport.ts
+++ b/packages/app/src/features/markdown/composables/useDocumentExport.ts
@@ -17,6 +17,7 @@ interface UseDocumentExportOptions {
   content: DeepReadonly<ShallowRef<string>>
   currentPath: DeepReadonly<Ref<null | string>>
   displayName: DeepReadonly<Ref<string>>
+  isMobile: DeepReadonly<Ref<boolean>>
 }
 
 interface UseDocumentExportReturn {
@@ -24,10 +25,18 @@ interface UseDocumentExportReturn {
   canExportPdf: Readonly<Ref<boolean>>
   exportHtml: () => Promise<void>
   exportPdf: () => Promise<void>
+  pdfExportUnavailableReason: Readonly<Ref<string>>
 }
 
 const PRINT_JOB_KEY = 'markdown-studio:print-export:'
 const PRINT_JOB_WINDOW_NAME_PREFIX = 'markdown-studio:print-export-window:'
+const MOBILE_PDF_EXPORT_UNAVAILABLE_REASON =
+  "PDF export isn't available on mobile or installed PWAs yet. Use Export as HTML instead."
+
+interface PdfExportSupportInput {
+  isDesktop: boolean
+  isMobile: boolean
+}
 
 export function cleanupPrintJob(jobId: string): void {
   if (typeof window === 'undefined') {
@@ -35,6 +44,30 @@ export function cleanupPrintJob(jobId: string): void {
   }
 
   window.localStorage.removeItem(getPrintJobStorageKey(jobId))
+}
+
+export function getPdfExportSupport(input: PdfExportSupportInput): {
+  isSupported: boolean
+  unavailableReason: string
+} {
+  if (input.isDesktop) {
+    return {
+      isSupported: true,
+      unavailableReason: '',
+    }
+  }
+
+  if (input.isMobile) {
+    return {
+      isSupported: false,
+      unavailableReason: MOBILE_PDF_EXPORT_UNAVAILABLE_REASON,
+    }
+  }
+
+  return {
+    isSupported: true,
+    unavailableReason: '',
+  }
 }
 
 export function readPrintJob(jobId: string): { bodyHtml: string; title: string } | null {
@@ -95,7 +128,16 @@ export function useDocumentExport(options: UseDocumentExportOptions): UseDocumen
   const router = useRouter()
 
   const canExportHtml = computed(() => typeof window !== 'undefined')
-  const canExportPdf = computed(() => typeof window !== 'undefined')
+  const pdfExportSupport = computed(() =>
+    getPdfExportSupport({
+      isDesktop: desktop.value.isDesktop,
+      isMobile: options.isMobile.value,
+    }),
+  )
+  const canExportPdf = computed(
+    () => typeof window !== 'undefined' && pdfExportSupport.value.isSupported,
+  )
+  const pdfExportUnavailableReason = computed(() => pdfExportSupport.value.unavailableReason)
 
   async function exportHtml(): Promise<void> {
     const rendered = await renderCurrentDocument()
@@ -115,6 +157,10 @@ export function useDocumentExport(options: UseDocumentExportOptions): UseDocumen
   }
 
   async function exportPdf(): Promise<void> {
+    if (!canExportPdf.value) {
+      throw new Error(pdfExportUnavailableReason.value || 'PDF export is not available.')
+    }
+
     const rendered = await renderCurrentDocument()
     const documentHtml = buildMarkdownDocumentHtml(rendered)
     const suggestedPath = getSuggestedExportFileName(getDocumentPath(), 'pdf')
@@ -156,6 +202,7 @@ export function useDocumentExport(options: UseDocumentExportOptions): UseDocumen
     canExportPdf,
     exportHtml,
     exportPdf,
+    pdfExportUnavailableReason,
   }
 
   function getDocumentPath(): string {

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -56,11 +56,6 @@ const {
   content,
   replaceContent: updateContent,
 })
-const { exportHtml, exportPdf } = useDocumentExport({
-  content,
-  currentPath,
-  displayName,
-})
 const {
   activeMatch,
   activeMatchIndex,
@@ -121,6 +116,14 @@ const {
   updateApp,
 } = usePwa()
 const mobileBreakpoint = 700
+const isExamplesModalOpen = shallowRef(false)
+const isMobile = shallowRef(false)
+const { canExportPdf, exportHtml, exportPdf, pdfExportUnavailableReason } = useDocumentExport({
+  content,
+  currentPath,
+  displayName,
+  isMobile,
+})
 
 const bannerStatus = computed(() =>
   updateAvailable.value ? ('update-available' as const) : ('up-to-date' as const),
@@ -132,9 +135,6 @@ const showPwaBanner = computed(
   () => !desktop.value.isDesktop && (needRefresh.value || offlineReady.value),
 )
 
-// Local state
-const isExamplesModalOpen = shallowRef(false)
-const isMobile = shallowRef(false)
 let removeDesktopCommandListener: () => void = () => undefined
 const editorPaneRef = useTemplateRef<InstanceType<typeof EditorPane>>('editorPane')
 const previewPaneRef = useTemplateRef<InstanceType<typeof PreviewPane>>('previewPane')
@@ -438,7 +438,9 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
       await exportHtml()
       return
     case 'document:exportPdf':
-      await exportPdf()
+      if (canExportPdf.value) {
+        await exportPdf()
+      }
       return
     case 'editor:find':
       handleFindShortcut()
@@ -459,11 +461,13 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
   <div class="markdown-studio" :class="bodyClasses">
     <Toolbar
       :available-modes="availableModes"
+      :can-export-pdf="canExportPdf"
       :can-open-documents="canOpenDocuments"
       :can-install="canInstall"
       :can-save-documents="canSaveDocuments"
       :is-mobile="isMobile"
       :view-mode="viewMode"
+      :pdf-export-unavailable-reason="pdfExportUnavailableReason"
       :theme="theme"
       :is-copied="isCopied"
       @install="handleInstall"


### PR DESCRIPTION
## Summary

This PR disables the "Export as PDF" action on mobile devices and installed PWAs (Progressive Web Apps) to provide a better user experience. PDF export is not supported on these platforms, so the action now displays in a disabled state with a tooltip explaining the limitation and suggesting "Export as HTML" as an alternative.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| PDF Export button was enabled but didn't work on mobile/PWA | PDF Export button shows as disabled with tooltip explaining why |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [x] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes:
  - Verified PDF export is disabled on mobile devices (touch screen detection)
  - Verified PDF export is disabled when app is installed as PWA (display-mode: standalone)
  - Verified tooltip appears explaining the limitation
  - Verified "Export as HTML" remains available as alternative
  - Verified behavior on desktop browser remains unchanged

## Related Issue

Fixes #39

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [x] UI changes have screenshots (if applicable)
