### PR TITLE
fix(desktop): correct version format with desktop- prefix

### DIFF
--- a/.changeset/fix-update-banner-version.md
+++ b/.changeset/fix-update-banner-version.md
@@ -1,0 +1,5 @@
+---
+"@markdown-studio/desktop": patch
+---
+
+Fix update banner showing incorrect version format with desktop- prefix (e.g., vdesktop-v0.4.0 instead of v0.4.0)

--- a/packages/app/src/features/markdown/components/UpdateBanner.vue
+++ b/packages/app/src/features/markdown/components/UpdateBanner.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { coerce } from '@/utils/semver'
+
 interface Props {
   currentVersion?: string
   latestVersion?: string
@@ -12,7 +14,7 @@ const emit = defineEmits<{
   download: []
 }>()
 
-const normalizeVersion = (v?: string) => v?.replace(/^v/, '')
+const normalizeVersion = (v?: string) => (v ? coerce(v) : undefined)
 </script>
 
 <template>

--- a/packages/app/src/utils/__tests__/semver.spec.ts
+++ b/packages/app/src/utils/__tests__/semver.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { compareSemver } from '../semver'
+import { coerce, compareSemver } from '../semver'
 
 describe('compareSemver', () => {
   it('returns 0 for equal versions', () => {
@@ -47,5 +47,25 @@ describe('compareSemver', () => {
   it('throws on invalid version strings', () => {
     expect(() => compareSemver('not-a-version', '1.0.0')).toThrow('Invalid semver')
     expect(() => compareSemver('1.0.0', '')).toThrow('Invalid semver')
+  })
+})
+
+describe('coerce', () => {
+  it('extracts semver from plain version', () => {
+    expect(coerce('1.2.3')).toBe('1.2.3')
+  })
+
+  it('strips v prefix', () => {
+    expect(coerce('v1.2.3')).toBe('1.2.3')
+  })
+
+  it('strips desktop-v prefix', () => {
+    expect(coerce('desktop-v1.2.3')).toBe('1.2.3')
+    expect(coerce('desktop-v0.4.0')).toBe('0.4.0')
+  })
+
+  it('throws on invalid version strings', () => {
+    expect(() => coerce('not-a-version')).toThrow('Invalid semver')
+    expect(() => coerce('')).toThrow('Invalid semver')
   })
 })

--- a/packages/app/src/utils/semver.ts
+++ b/packages/app/src/utils/semver.ts
@@ -1,6 +1,19 @@
 import semver from 'semver'
 
 /**
+ * Normalize a version string by extracting the semver portion.
+ * Handles plain versions (1.2.3), v-prefix (v1.2.3), and
+ * tagged formats like desktop-v1.2.3.
+ */
+export function coerce(version: string): string {
+  const coerced = semver.coerce(version)
+  if (!coerced) {
+    throw new Error(`Invalid semver: "${version}"`)
+  }
+  return coerced.version
+}
+
+/**
  * Compare two semver version strings.
  *
  * Accepts plain versions (1.2.3), v-prefixed (v1.2.3), and
@@ -10,17 +23,4 @@ import semver from 'semver'
  */
 export function compareSemver(a: string, b: string): number {
   return semver.compare(coerce(a), coerce(b))
-}
-
-/**
- * Normalize a version string by extracting the semver portion.
- * Handles plain versions (1.2.3), v-prefix (v1.2.3), and
- * tagged formats like desktop-v1.2.3.
- */
-function coerce(version: string): string {
-  const coerced = semver.coerce(version)
-  if (!coerced) {
-    throw new Error(`Invalid semver: "${version}"`)
-  }
-  return coerced.version
 }


### PR DESCRIPTION
## Summary

Fixes the update banner displaying incorrect version format with desktop- prefix (e.g., vdesktop-v0.4.0 instead of v0.4.0). Exports the `coerce` function from semver utility and uses it in UpdateBanner to properly strip the desktop-v prefix. Adds comprehensive tests for the coerce function covering all version formats.

## Type of Change

- [x] Bug fix

## Screenshots

No UI changes visible to user (only version string formatting).

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [x] E2E tests pass: `pnpm test:e2e` (if applicable) - N/A for this change
- [x] Manual testing notes: Tested with various version formats (plain, v-prefixed, desktop-v-prefixed) to ensure proper coercion.

## Related Issue

Fixes #35

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [x] UI changes have screenshots (if applicable) - N/A