### PR TITLE
refactor(markdown): introduce useEditorWorkspaceController boundary and pane adapter types

### DIFF
--- a/.changeset/refactor-workspace-controller.md
+++ b/.changeset/refactor-workspace-controller.md
@@ -1,0 +1,11 @@
+---
+"markdown-studio": patch
+"@markdown-studio/desktop": patch
+---
+
+Refactor markdown workspace with controller boundary
+- Introduce `useEditorWorkspaceController` for workspace orchestration
+- Define shared editor and preview pane adapter interfaces
+- Move route view coordination behind controller state and APIs
+- Reuse shared workspace types in pane and toolbar components
+- Add controller-focused tests for shortcuts, sync, and draft restore

--- a/packages/app/src/features/markdown/components/EditorPane.vue
+++ b/packages/app/src/features/markdown/components/EditorPane.vue
@@ -6,17 +6,10 @@ import type { AppWindow } from '@/browser-window'
 import { insertTextAtSelection } from '@/utils/insertTextAtSelection'
 
 import type { FindMatch } from '../composables/useFindReplace'
+import type { EditorScrollPayload } from '../types'
 
 import FindReplaceBar from './FindReplaceBar.vue'
 import MatchOverlay from './MatchOverlay.vue'
-
-interface EditorScrollState {
-  clientHeight: number
-  contentLength: number
-  lineHeight: number
-  scrollHeight: number
-  scrollTop: number
-}
 
 interface Props {
   activeMatchIndex?: number
@@ -50,7 +43,7 @@ const emit = defineEmits<{
   'find:replace-current': []
   'request-find': []
   'request-replace': []
-  scroll: [payload: EditorScrollState]
+  scroll: [payload: EditorScrollPayload]
   'update:content': [value: string]
   'update:match-case': [value: boolean]
   'update:query': [value: string]
@@ -111,7 +104,7 @@ function getLineIndexForOffset(offset: number): number {
   return lineIndex
 }
 
-function getScrollState(): EditorScrollState | null {
+function getScrollState(): EditorScrollPayload | null {
   const editor = editorRef.value
   if (!editor) return null
 

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -7,7 +7,7 @@ import ToolbarButton from '@/components/base/ToolbarButton.vue'
 import ViewToggle from '@/components/base/ViewToggle.vue'
 import { GITHUB_REPO_URL } from '@/utils/constants'
 
-import type { Theme, ViewMode } from '../types'
+import type { Theme, ThemeChangeRequest, ViewMode } from '../types'
 
 interface Props {
   availableModes?: ViewMode[]
@@ -20,11 +20,6 @@ interface Props {
   pdfExportUnavailableReason?: string
   theme: Theme
   viewMode: ViewMode
-}
-
-interface ThemeChangeRequest {
-  origin: { x: number; y: number }
-  theme: Theme
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -1,0 +1,223 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import type { AppWindow } from '@/browser-window'
+import type {
+  EditorPaneAdapter,
+  EditorWorkspaceController,
+  PreviewPaneAdapter,
+} from '@/features/markdown/types'
+
+import { resetPwaStateForTests } from '@/composables/usePwa'
+
+import { resetBrowserDocumentSessionForTests } from '../useDocumentActions'
+import { useEditorWorkspaceController } from '../useEditorWorkspaceController'
+
+function createEditorAdapter(): EditorPaneAdapter {
+  return {
+    focus: vi.fn(),
+    focusAtOffset: vi.fn(async () => undefined),
+    focusFindQuery: vi.fn(),
+    getScrollState: vi.fn(() => null),
+    replaceAllContent: vi.fn(async () => undefined),
+    replaceRange: vi.fn(async () => undefined),
+    setSelectionRange: vi.fn(async () => undefined),
+  }
+}
+
+function createPreviewAdapter(): PreviewPaneAdapter {
+  return {
+    scrollToSourceOffset: vi.fn(),
+  }
+}
+
+function createRouterForTest() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { component: { render: () => h('div') }, name: 'home', path: '/' },
+      { component: { render: () => h('div') }, name: 'print-export', path: '/export/print' },
+    ],
+  })
+}
+
+async function mountWorkspace() {
+  let workspace: EditorWorkspaceController | undefined
+
+  const Harness = defineComponent({
+    setup() {
+      workspace = useEditorWorkspaceController()
+      return () => h('div')
+    },
+  })
+
+  const router = createRouterForTest()
+  await router.push('/')
+  await router.isReady()
+
+  const wrapper = mount(Harness, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  if (!workspace) {
+    throw new Error('Workspace controller was not created.')
+  }
+
+  return {
+    router,
+    workspace,
+    wrapper,
+  }
+}
+
+describe('useEditorWorkspaceController', () => {
+  const appWindow = window as AppWindow
+  const originalDesktop = appWindow.desktop
+  const originalConfirm = window.confirm
+
+  beforeEach(() => {
+    resetBrowserDocumentSessionForTests()
+    resetPwaStateForTests()
+    appWindow.desktop = undefined
+    window.confirm = vi.fn(() => true)
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    resetBrowserDocumentSessionForTests()
+    resetPwaStateForTests()
+    appWindow.desktop = originalDesktop
+    window.confirm = originalConfirm
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('opens replace from the global shortcut and focuses the editor find query', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+
+    workspace.system.handleGlobalKeydown(
+      new KeyboardEvent('keydown', {
+        ctrlKey: true,
+        key: 'h',
+      }),
+    )
+    await nextTick()
+
+    expect(workspace.state.isFindReplaceOpen.value).toBe(true)
+    expect(workspace.state.showReplace.value).toBe(true)
+    expect(editor.focusFindQuery).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('replaces the current match through the editor adapter and restores editor focus', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+
+    workspace.editor.updateContent('cat dog cat')
+    workspace.find.setQuery('cat')
+    workspace.find.setReplaceText('fox')
+
+    await workspace.find.replaceCurrent()
+
+    expect(editor.replaceRange).toHaveBeenCalledWith(0, 3, 'fox')
+    expect(editor.focus).toHaveBeenCalledTimes(1)
+    expect(workspace.state.activeMatchIndex.value).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  it('syncs preview position from editor scroll only in split mode', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const preview = createPreviewAdapter()
+    workspace.attach.preview(preview)
+
+    workspace.editor.updateContent('one\ntwo\nthree\nfour')
+    workspace.editor.setViewMode('split')
+    workspace.editor.syncPreviewToEditorPosition({
+      clientHeight: 200,
+      contentLength: workspace.state.content.value.length,
+      lineHeight: 20,
+      scrollHeight: 400,
+      scrollTop: 40,
+    })
+
+    expect(preview.scrollToSourceOffset).toHaveBeenCalledWith(8)
+
+    vi.mocked(preview.scrollToSourceOffset).mockClear()
+    workspace.editor.setViewMode('preview')
+    workspace.editor.syncPreviewToEditorPosition({
+      clientHeight: 200,
+      contentLength: workspace.state.content.value.length,
+      lineHeight: 20,
+      scrollHeight: 400,
+      scrollTop: 40,
+    })
+
+    expect(preview.scrollToSourceOffset).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('jumps from preview to editor offsets only while split view is active', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+
+    workspace.editor.setViewMode('split')
+    await workspace.preview.jumpToOffset(12)
+    expect(editor.focusAtOffset).toHaveBeenCalledWith(12)
+
+    vi.mocked(editor.focusAtOffset).mockClear()
+    workspace.editor.setViewMode('editor')
+    await workspace.preview.jumpToOffset(24)
+    expect(editor.focusAtOffset).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('collapses split view to editor mode on mobile viewport changes', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+
+    workspace.editor.setViewMode('split')
+    workspace.system.handleViewportResize(640)
+
+    expect(workspace.state.isMobile.value).toBe(true)
+    expect(workspace.state.viewMode.value).toBe('editor')
+    expect(workspace.state.availableModes.value).toEqual(['editor', 'preview'])
+
+    wrapper.unmount()
+  })
+
+  it('restores a stored draft during startup on the web', async () => {
+    vi.useFakeTimers()
+    window.localStorage.setItem(
+      'markdown-studio:web-draft',
+      JSON.stringify({
+        content: '# Restored draft',
+        label: 'notes.md',
+      }),
+    )
+
+    const { workspace, wrapper } = await mountWorkspace()
+
+    await workspace.system.start()
+    await flushPromises()
+
+    expect(workspace.state.content.value).toBe('# Restored draft')
+    expect(workspace.state.displayName.value).toBe('notes.md')
+    expect(workspace.state.isDirty.value).toBe(true)
+
+    workspace.system.stop()
+    wrapper.unmount()
+  })
+})

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -1,0 +1,555 @@
+import type { AppCommand } from '@markdown-studio/desktop-contract/types'
+
+import { computed, nextTick, shallowRef, watch } from 'vue'
+
+import { useDesktop } from '@/composables/useDesktop'
+import { usePwa } from '@/composables/usePwa'
+import { useThemeTransition } from '@/composables/useThemeTransition'
+import { useUpdateChecker } from '@/composables/useUpdateChecker'
+
+import type { ViewMode } from '../types'
+import type {
+  EditorPaneAdapter,
+  EditorScrollPayload,
+  EditorWorkspaceController,
+  PreviewPaneAdapter,
+  ThemeChangeRequest,
+} from '../types/workspace'
+
+import { useDocumentExport } from './useDocumentExport'
+import { useDocumentSession } from './useDocumentSession'
+import { useFindReplace } from './useFindReplace'
+import { useMarkdownEditor } from './useMarkdownEditor'
+import { useWebDraftPersistence } from './useWebDraftPersistence'
+
+const MOBILE_BREAKPOINT = 700
+
+/**
+ * Initial controller boundary for editor workspace orchestration.
+ *
+ * This module intentionally preserves the current behavior while moving the
+ * integration seams out of the route view. Follow-up issues can deepen the
+ * controller further without re-introducing view-level coordination.
+ */
+export function useEditorWorkspaceController(): EditorWorkspaceController {
+  const editorPane = shallowRef<EditorPaneAdapter | null>(null)
+  const previewPane = shallowRef<null | PreviewPaneAdapter>(null)
+  const isExamplesModalOpen = shallowRef(false)
+  const isMobile = shallowRef(false)
+
+  const {
+    content,
+    copyContent,
+    isCopied,
+    loadExample,
+    renderedHtml,
+    renderMermaidDiagrams,
+    setTheme,
+    setViewMode,
+    sourceMap,
+    stats,
+    theme,
+    updateContent,
+    viewMode,
+  } = useMarkdownEditor()
+  const desktop = useDesktop()
+  const {
+    canOpenDocuments,
+    canSaveDocuments,
+    currentPath,
+    displayName,
+    handleAppCommand,
+    isDesktop,
+    isDirty,
+    openDocument,
+    restoreDraft,
+    saveDocument,
+    startNewDocument,
+    statusText,
+  } = useDocumentSession({
+    content,
+    replaceContent: updateContent,
+  })
+  const {
+    activeMatch,
+    activeMatchIndex,
+    close: closeFindReplace,
+    commitReplacement,
+    findNext,
+    findPrevious,
+    isOpen: isFindReplaceOpen,
+    matchCase,
+    matchCount,
+    matches,
+    openFind,
+    openReplace,
+    prepareReplaceAll,
+    prepareReplaceCurrent,
+    query,
+    replaceText,
+    requestSelectionSync,
+    setMatchCase,
+    setQuery,
+    setReplaceText,
+    showReplace,
+  } = useFindReplace({
+    content,
+  })
+  const { transitionTheme } = useThemeTransition()
+  const {
+    checkNow,
+    dismiss: dismissUpdateBanner,
+    download: downloadUpdate,
+    showBanner,
+    startChecking: startUpdateChecks,
+    stopChecking: stopUpdateChecks,
+    updateAvailable,
+    updateInfo,
+  } = useUpdateChecker()
+  const {
+    canInstall,
+    dismissOfflineReady,
+    dismissRefreshPrompt,
+    install,
+    needRefresh,
+    offlineReady,
+    updateApp,
+  } = usePwa()
+  const { canExportPdf, exportHtml, exportPdf, pdfExportUnavailableReason } = useDocumentExport({
+    content,
+    currentPath,
+    displayName,
+    isMobile,
+  })
+  const { clearDraft, restoreStoredDraft } = useWebDraftPersistence({
+    content,
+    displayName,
+    isDesktop,
+    isDirty,
+    restoreDraft,
+  })
+
+  const bannerStatus = computed(() =>
+    updateAvailable.value ? ('update-available' as const) : ('up-to-date' as const),
+  )
+  const pwaBannerStatus = computed(() =>
+    needRefresh.value ? ('update-available' as const) : ('offline-ready' as const),
+  )
+  const showPwaBanner = computed(
+    () => !desktop.value.isDesktop && (needRefresh.value || offlineReady.value),
+  )
+  const availableModes = computed(() =>
+    isMobile.value
+      ? (['editor', 'preview'] satisfies ViewMode[])
+      : (['editor', 'split', 'preview'] satisfies ViewMode[]),
+  )
+  const bodyClasses = computed(() => ({
+    'is-mobile': isMobile.value,
+    'view-editor': viewMode.value === 'editor',
+    'view-preview': viewMode.value === 'preview',
+    'view-split': viewMode.value === 'split',
+  }))
+
+  let removeDesktopCommandListener: () => void = () => undefined
+
+  watch(
+    theme,
+    (newTheme) => {
+      document.documentElement.setAttribute('data-theme', newTheme)
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => [content.value, isMobile.value, sourceMap.value, viewMode.value],
+    async () => {
+      await nextTick()
+      syncPreviewToEditorPosition()
+    },
+    { deep: true },
+  )
+
+  watch(requestSelectionSync, () => {
+    syncFindSelection()
+  })
+
+  function attachEditor(adapter: EditorPaneAdapter): void {
+    editorPane.value = adapter
+  }
+
+  function attachPreview(adapter: PreviewPaneAdapter): void {
+    previewPane.value = adapter
+  }
+
+  function closeExamples(): void {
+    isExamplesModalOpen.value = false
+  }
+
+  function openExamples(): void {
+    isExamplesModalOpen.value = true
+  }
+
+  function focusFindQuery(): void {
+    void nextTick(() => {
+      editorPane.value?.focusFindQuery()
+    })
+  }
+
+  function getOffsetForLine(contentValue: string, lineNumber: number): number {
+    if (lineNumber <= 0) return 0
+
+    let currentLine = 0
+
+    for (let index = 0; index < contentValue.length; index += 1) {
+      if (contentValue[index] === '\n') {
+        currentLine += 1
+        if (currentLine === lineNumber) {
+          return index + 1
+        }
+      }
+    }
+
+    return contentValue.length
+  }
+
+  async function handleDesktopCommand(command: AppCommand): Promise<void> {
+    switch (command) {
+      case 'document:exportHtml':
+        await exportHtml()
+        return
+      case 'document:exportPdf':
+        if (canExportPdf.value) {
+          await exportPdf()
+        }
+        return
+      case 'editor:find':
+        openFindPanel()
+        return
+      case 'editor:replace':
+        openReplacePanel()
+        return
+      case 'update:check':
+        await checkNow()
+        return
+      default:
+        await handleAppCommand(command)
+    }
+  }
+
+  function openFindPanel(): void {
+    openFind()
+    focusFindQuery()
+  }
+
+  function openReplacePanel(): void {
+    openReplace()
+    focusFindQuery()
+  }
+
+  function syncFindSelection(): void {
+    const match = activeMatch.value
+    if (!match) {
+      return
+    }
+
+    void nextTick(() => {
+      void editorPane.value?.setSelectionRange(match.index, match.end)
+    })
+  }
+
+  function syncPreviewToEditorPosition(scrollState?: EditorScrollPayload | null): void {
+    if (isMobile.value || viewMode.value !== 'split') return
+
+    const effectiveScrollState = scrollState ?? editorPane.value?.getScrollState()
+    if (!effectiveScrollState) return
+
+    const topLine = Math.max(
+      0,
+      Math.floor(effectiveScrollState.scrollTop / effectiveScrollState.lineHeight),
+    )
+    const sourceOffset = getOffsetForLine(content.value, topLine)
+    previewPane.value?.scrollToSourceOffset(sourceOffset)
+  }
+
+  function syncViewport(width: number): void {
+    const nextIsMobile = width <= MOBILE_BREAKPOINT
+    isMobile.value = nextIsMobile
+
+    if (nextIsMobile && viewMode.value === 'split') {
+      setViewMode('editor')
+    }
+  }
+
+  async function replaceAll(): Promise<void> {
+    const replacementPlan = prepareReplaceAll()
+    if (!replacementPlan) {
+      return
+    }
+
+    await editorPane.value?.replaceAllContent(replacementPlan.nextContent)
+    commitReplacement(replacementPlan.nextActiveIndex)
+    editorPane.value?.focus()
+  }
+
+  async function replaceCurrent(): Promise<void> {
+    const replacementPlan = prepareReplaceCurrent()
+    if (!replacementPlan) {
+      return
+    }
+
+    await editorPane.value?.replaceRange(
+      replacementPlan.match.index,
+      replacementPlan.match.end,
+      replacementPlan.replacement,
+    )
+    commitReplacement(replacementPlan.nextActiveIndex)
+    editorPane.value?.focus()
+  }
+
+  async function startNew(): Promise<void> {
+    await startNewDocument()
+    if (!content.value) {
+      clearDraft()
+    }
+  }
+
+  async function setWorkspaceTheme(request: ThemeChangeRequest): Promise<void> {
+    if (request.theme === theme.value) return
+
+    await transitionTheme(request.theme, setTheme, {
+      origin: request.origin,
+    })
+  }
+
+  async function loadWorkspaceExample(example: Parameters<typeof loadExample>[0]): Promise<void> {
+    loadExample(example)
+    setTimeout(() => {
+      editorPane.value?.focus()
+    }, 0)
+  }
+
+  async function jumpToOffset(offset: number): Promise<void> {
+    if (isMobile.value || viewMode.value !== 'split') return
+
+    await editorPane.value?.focusAtOffset(offset)
+  }
+
+  async function start(): Promise<void> {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    syncViewport(window.innerWidth)
+    window.addEventListener('resize', handleWindowResize)
+    window.addEventListener('keydown', handleGlobalKeydown)
+    startUpdateChecks()
+    await restoreStoredDraft()
+
+    const onAppCommand = desktop.value?.commands?.onAppCommand
+    if (onAppCommand) {
+      removeDesktopCommandListener = onAppCommand((command: AppCommand) => {
+        void handleDesktopCommand(command).catch((error: unknown) => {
+          console.error('Failed to handle desktop app command:', error)
+        })
+      })
+    } else {
+      removeDesktopCommandListener = () => undefined
+    }
+  }
+
+  function stop(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', handleWindowResize)
+      window.removeEventListener('keydown', handleGlobalKeydown)
+    }
+
+    removeDesktopCommandListener()
+    removeDesktopCommandListener = () => undefined
+    stopUpdateChecks()
+  }
+
+  function handleWindowResize(): void {
+    handleViewportResize(window.innerWidth)
+  }
+
+  function handleViewportResize(width: number): void {
+    syncViewport(width)
+  }
+
+  function handleGlobalKeydown(event: KeyboardEvent): void {
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const normalizedKey = event.key.toLowerCase()
+    const hasCommandModifier = event.metaKey || event.ctrlKey
+
+    if (hasCommandModifier && normalizedKey === 'f') {
+      event.preventDefault()
+      openFindPanel()
+      return
+    }
+
+    if (hasCommandModifier && normalizedKey === 'h') {
+      event.preventDefault()
+      openReplacePanel()
+      return
+    }
+
+    if (!isFindReplaceOpen.value) {
+      return
+    }
+
+    if ((hasCommandModifier && normalizedKey === 'g') || event.key === 'F3') {
+      event.preventDefault()
+      if (event.shiftKey) {
+        findPrevious()
+        return
+      }
+
+      findNext()
+    }
+  }
+
+  function closeFind(): void {
+    closeFindReplace()
+    editorPane.value?.focus()
+  }
+
+  function dismissPwaBanner(): void {
+    if (needRefresh.value) {
+      dismissRefreshPrompt()
+      return
+    }
+
+    dismissOfflineReady()
+  }
+
+  async function installApp(): Promise<void> {
+    await install()
+  }
+
+  return {
+    attach: {
+      editor: attachEditor,
+      preview: attachPreview,
+    },
+    document: {
+      async handleAppCommand(command: AppCommand): Promise<void> {
+        await handleDesktopCommand(command)
+      },
+      async open(): Promise<void> {
+        await openDocument()
+      },
+      async restoreDraft(): Promise<void> {
+        await restoreStoredDraft()
+      },
+      async save(): Promise<void> {
+        await saveDocument()
+      },
+      async startNew(): Promise<void> {
+        await startNew()
+      },
+    },
+    editor: {
+      async loadExample(example) {
+        await loadWorkspaceExample(example)
+      },
+      async setTheme(request: ThemeChangeRequest) {
+        await setWorkspaceTheme(request)
+      },
+      setViewMode,
+      syncPreviewToEditorPosition,
+      updateContent,
+    },
+    examples: {
+      close: closeExamples,
+      open: openExamples,
+    },
+    export: {
+      async html(): Promise<void> {
+        await exportHtml()
+      },
+      async pdf(): Promise<void> {
+        await exportPdf()
+      },
+    },
+    find: {
+      close: closeFind,
+      next: findNext,
+      open: openFindPanel,
+      openReplace: openReplacePanel,
+      previous: findPrevious,
+      async replaceAll(): Promise<void> {
+        await replaceAll()
+      },
+      async replaceCurrent(): Promise<void> {
+        await replaceCurrent()
+      },
+      setMatchCase,
+      setQuery,
+      setReplaceText,
+    },
+    preview: {
+      async jumpToOffset(offset: number): Promise<void> {
+        await jumpToOffset(offset)
+      },
+      async renderDiagrams(container: HTMLElement): Promise<void> {
+        await renderMermaidDiagrams(container)
+      },
+    },
+    state: {
+      activeMatchIndex,
+      availableModes,
+      bannerStatus,
+      bodyClasses,
+      canExportPdf,
+      canInstall,
+      canOpenDocuments,
+      canSaveDocuments,
+      content,
+      currentPath,
+      displayName,
+      isCopied,
+      isDesktop,
+      isDirty,
+      isExamplesModalOpen,
+      isFindReplaceOpen,
+      isMobile,
+      matchCase,
+      matchCount,
+      matches,
+      needRefresh,
+      offlineReady,
+      pdfExportUnavailableReason,
+      pwaBannerStatus,
+      query,
+      renderedHtml,
+      replaceText,
+      showBanner,
+      showPwaBanner,
+      showReplace,
+      sourceMap,
+      stats,
+      statusText,
+      theme,
+      updateAvailable,
+      updateInfo,
+      viewMode,
+    },
+    system: {
+      handleGlobalKeydown,
+      handleViewportResize,
+      start,
+      stop,
+    },
+    toolbar: {
+      copy: copyContent,
+      dismissPwaBanner,
+      dismissUpdateBanner,
+      downloadUpdate,
+      install: installApp,
+      updateApp,
+    },
+  }
+}

--- a/packages/app/src/features/markdown/index.ts
+++ b/packages/app/src/features/markdown/index.ts
@@ -2,8 +2,21 @@ export { DEFAULT_EXAMPLE_INDEX, EXAMPLES } from './composables/examples'
 export { renderMarkdownWithSourceMap } from './composables/renderMarkdownWithSourceMap'
 export { useDocumentExport } from './composables/useDocumentExport'
 // Composables
+export { useEditorWorkspaceController } from './composables/useEditorWorkspaceController'
 export { useMarkdownEditor } from './composables/useMarkdownEditor'
 
 // Types
-export type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './types'
+export type {
+  EditorPaneAdapter,
+  EditorScrollPayload,
+  EditorStats,
+  EditorWorkspaceController,
+  EditorWorkspaceState,
+  Example,
+  MarkdownSourceMapEntry,
+  PreviewPaneAdapter,
+  Theme,
+  ThemeChangeRequest,
+  ViewMode,
+} from './types'
 export { buildMarkdownDocumentHtml, renderMarkdownDocument } from './utils/renderMarkdownDocument'

--- a/packages/app/src/features/markdown/types/index.ts
+++ b/packages/app/src/features/markdown/types/index.ts
@@ -20,3 +20,12 @@ export interface MarkdownSourceMapEntry {
 
 export type Theme = 'dark' | 'light'
 export type ViewMode = 'editor' | 'preview' | 'split'
+
+export type {
+  EditorPaneAdapter,
+  EditorScrollPayload,
+  EditorWorkspaceController,
+  EditorWorkspaceState,
+  PreviewPaneAdapter,
+  ThemeChangeRequest,
+} from './workspace'

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -1,0 +1,159 @@
+import type { AppCommand } from '@markdown-studio/desktop-contract/types'
+import type { ComputedRef, Ref, ShallowRef } from 'vue'
+
+import type { FindMatch } from '../composables/useFindReplace'
+import type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './index'
+
+/**
+ * Imperative capabilities exposed by the editor pane.
+ *
+ * The workspace controller depends on this adapter instead of the concrete Vue
+ * component instance so orchestration can move away from the route view without
+ * coupling the controller to a specific UI implementation.
+ */
+export interface EditorPaneAdapter {
+  focus(): void
+  focusAtOffset(offset: number): Promise<void>
+  focusFindQuery(): void
+  getScrollState(): EditorScrollPayload | null
+  replaceAllContent(content: string): Promise<void>
+  replaceRange(start: number, end: number, replacement: string): Promise<void>
+  setSelectionRange(start: number, end: number): Promise<void>
+}
+
+/**
+ * Shared scroll payload used by the editor pane and workspace controller.
+ *
+ * The initial controller boundary keeps this shape intentionally close to the
+ * existing pane contract so follow-up refactors can move behavior without
+ * changing runtime semantics.
+ */
+export interface EditorScrollPayload {
+  clientHeight: number
+  contentLength: number
+  lineHeight: number
+  scrollHeight: number
+  scrollTop: number
+}
+
+export interface EditorWorkspaceController {
+  attach: {
+    editor(adapter: EditorPaneAdapter): void
+    preview(adapter: PreviewPaneAdapter): void
+  }
+  document: {
+    handleAppCommand(command: AppCommand): Promise<void>
+    open(): Promise<void>
+    restoreDraft(): Promise<void>
+    save(): Promise<void>
+    startNew(): Promise<void>
+  }
+  editor: {
+    loadExample(example: Example): Promise<void>
+    setTheme(request: ThemeChangeRequest): Promise<void>
+    setViewMode(mode: ViewMode): void
+    syncPreviewToEditorPosition(payload?: EditorScrollPayload | null): void
+    updateContent(value: string): void
+  }
+  examples: {
+    close(): void
+    open(): void
+  }
+  export: {
+    html(): Promise<void>
+    pdf(): Promise<void>
+  }
+  find: {
+    close(): void
+    next(): void
+    open(): void
+    openReplace(): void
+    previous(): void
+    replaceAll(): Promise<void>
+    replaceCurrent(): Promise<void>
+    setMatchCase(value: boolean): void
+    setQuery(value: string): void
+    setReplaceText(value: string): void
+  }
+  preview: {
+    jumpToOffset(offset: number): Promise<void>
+    renderDiagrams(container: HTMLElement): Promise<void>
+  }
+  state: EditorWorkspaceState
+  system: {
+    handleGlobalKeydown(event: KeyboardEvent): void
+    handleViewportResize(width: number): void
+    start(): Promise<void>
+    stop(): void
+  }
+  toolbar: {
+    copy(): Promise<void>
+    dismissPwaBanner(): void
+    dismissUpdateBanner(): void
+    downloadUpdate(): void
+    install(): Promise<void>
+    updateApp(): Promise<void>
+  }
+}
+
+/**
+ * Controller-facing state shape consumed by the workspace view.
+ *
+ * The view intentionally reads from this object and forwards events back into
+ * controller methods. This makes the route component a composition surface
+ * rather than the primary orchestration owner.
+ */
+export interface EditorWorkspaceState {
+  activeMatchIndex: Readonly<Ref<number>>
+  availableModes: Readonly<Ref<ViewMode[]>>
+  bannerStatus: Readonly<Ref<'up-to-date' | 'update-available'>>
+  bodyClasses: ComputedRef<Record<string, boolean>>
+  canExportPdf: Readonly<Ref<boolean>>
+  canInstall: Readonly<Ref<boolean>>
+  canOpenDocuments: Readonly<Ref<boolean>>
+  canSaveDocuments: Readonly<Ref<boolean>>
+  content: Readonly<Ref<string>>
+  currentPath: Readonly<Ref<null | string>>
+  displayName: Readonly<Ref<string>>
+  isCopied: Readonly<Ref<boolean>>
+  isDesktop: Readonly<Ref<boolean>>
+  isDirty: Readonly<Ref<boolean>>
+  isExamplesModalOpen: ShallowRef<boolean>
+  isFindReplaceOpen: Readonly<Ref<boolean>>
+  isMobile: ShallowRef<boolean>
+  matchCase: Readonly<Ref<boolean>>
+  matchCount: Readonly<Ref<number>>
+  matches: Readonly<Ref<FindMatch[]>>
+  needRefresh: Readonly<Ref<boolean>>
+  offlineReady: Readonly<Ref<boolean>>
+  pdfExportUnavailableReason: Readonly<Ref<string>>
+  pwaBannerStatus: Readonly<Ref<'offline-ready' | 'update-available'>>
+  query: Readonly<Ref<string>>
+  renderedHtml: Readonly<Ref<string>>
+  replaceText: Readonly<Ref<string>>
+  showBanner: Readonly<Ref<boolean>>
+  showPwaBanner: Readonly<Ref<boolean>>
+  showReplace: Readonly<Ref<boolean>>
+  sourceMap: Readonly<Ref<MarkdownSourceMapEntry[]>>
+  stats: Readonly<Ref<EditorStats>>
+  statusText: Readonly<Ref<string>>
+  theme: Readonly<Ref<Theme>>
+  updateAvailable: Readonly<Ref<boolean>>
+  updateInfo: Readonly<Ref<null | WorkspaceUpdateInfo>>
+  viewMode: Readonly<Ref<ViewMode>>
+}
+
+export interface PreviewPaneAdapter {
+  scrollToSourceOffset(offset: number): void
+}
+
+export interface ThemeChangeRequest {
+  origin: { x: number; y: number }
+  theme: Theme
+}
+
+export interface WorkspaceUpdateInfo {
+  currentVersion: string
+  latestVersion: string
+  releaseUrl: string
+}

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -1,14 +1,8 @@
 <script setup lang="ts">
-import type { AppCommand } from '@markdown-studio/desktop-contract/types'
+import { onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
 
-import { computed, nextTick, onMounted, onUnmounted, shallowRef, useTemplateRef, watch } from 'vue'
+import type { EditorScrollPayload } from '@/features/markdown/types'
 
-import type { Example, Theme, ViewMode } from '@/features/markdown/types'
-
-import { useDesktop } from '@/composables/useDesktop'
-import { usePwa } from '@/composables/usePwa'
-import { useThemeTransition } from '@/composables/useThemeTransition'
-import { useUpdateChecker } from '@/composables/useUpdateChecker'
 import EditorPane from '@/features/markdown/components/EditorPane.vue'
 import ExamplesModal from '@/features/markdown/components/ExamplesModal.vue'
 import PreviewPane from '@/features/markdown/components/PreviewPane.vue'
@@ -16,445 +10,115 @@ import PwaBanner from '@/features/markdown/components/PwaBanner.vue'
 import StatusBar from '@/features/markdown/components/StatusBar.vue'
 import Toolbar from '@/features/markdown/components/Toolbar.vue'
 import UpdateBanner from '@/features/markdown/components/UpdateBanner.vue'
-import { useDocumentExport } from '@/features/markdown/composables/useDocumentExport'
-import { useDocumentSession } from '@/features/markdown/composables/useDocumentSession'
-import { useFindReplace } from '@/features/markdown/composables/useFindReplace'
-import { useMarkdownEditor } from '@/features/markdown/composables/useMarkdownEditor'
-import { useWebDraftPersistence } from '@/features/markdown/composables/useWebDraftPersistence'
+import { useEditorWorkspaceController } from '@/features/markdown/composables/useEditorWorkspaceController'
 
-// Use the composable
+const workspace = useEditorWorkspaceController()
 const {
-  content,
-  copyContent,
-  isCopied,
-  loadExample,
-  renderedHtml,
-  renderMermaidDiagrams,
-  setTheme,
-  setViewMode,
-  sourceMap,
-  stats,
-  theme,
-  updateContent,
-  viewMode,
-} = useMarkdownEditor()
-const desktop = useDesktop()
-const {
+  activeMatchIndex,
+  availableModes,
+  bannerStatus,
+  bodyClasses,
+  canExportPdf,
+  canInstall,
   canOpenDocuments,
   canSaveDocuments,
-  currentPath,
-  displayName,
-  handleAppCommand,
-  isDesktop,
-  isDirty,
-  openDocument,
-  restoreDraft,
-  saveDocument,
-  startNewDocument,
-  statusText,
-} = useDocumentSession({
   content,
-  replaceContent: updateContent,
-})
-const {
-  activeMatch,
-  activeMatchIndex,
-  close: closeFindReplace,
-  commitReplacement,
-  findNext,
-  findPrevious,
-  isOpen: isFindReplaceOpen,
+  displayName,
+  isCopied,
+  isDirty,
+  isExamplesModalOpen,
+  isFindReplaceOpen,
+  isMobile,
   matchCase,
   matchCount,
   matches,
-  openFind: openFindPanel,
-  openReplace: openReplacePanel,
-  prepareReplaceAll,
-  prepareReplaceCurrent,
+  pdfExportUnavailableReason,
+  pwaBannerStatus,
   query,
+  renderedHtml,
   replaceText,
-  requestSelectionSync,
-  setMatchCase,
-  setQuery,
-  setReplaceText,
-  showReplace,
-} = useFindReplace({
-  content,
-})
-
-interface EditorScrollPayload {
-  clientHeight: number
-  contentLength: number
-  lineHeight: number
-  scrollHeight: number
-  scrollTop: number
-}
-
-interface ThemeChangeRequest {
-  origin: { x: number; y: number }
-  theme: Theme
-}
-
-const { transitionTheme } = useThemeTransition()
-const {
-  checkNow,
-  dismiss: dismissUpdateBanner,
-  download: downloadUpdate,
   showBanner,
-  startChecking: startUpdateChecks,
-  stopChecking: stopUpdateChecks,
-  updateAvailable,
+  showPwaBanner,
+  showReplace,
+  sourceMap,
+  stats,
+  statusText,
+  theme,
   updateInfo,
-} = useUpdateChecker()
-const {
-  canInstall,
-  dismissOfflineReady,
-  dismissRefreshPrompt,
-  install,
-  needRefresh,
-  offlineReady,
-  updateApp,
-} = usePwa()
-const mobileBreakpoint = 700
-const isExamplesModalOpen = shallowRef(false)
-const isMobile = shallowRef(false)
-const { canExportPdf, exportHtml, exportPdf, pdfExportUnavailableReason } = useDocumentExport({
-  content,
-  currentPath,
-  displayName,
-  isMobile,
-})
-
-const bannerStatus = computed(() =>
-  updateAvailable.value ? ('update-available' as const) : ('up-to-date' as const),
-)
-const pwaBannerStatus = computed(() =>
-  needRefresh.value ? ('update-available' as const) : ('offline-ready' as const),
-)
-const showPwaBanner = computed(
-  () => !desktop.value.isDesktop && (needRefresh.value || offlineReady.value),
-)
-
-let removeDesktopCommandListener: () => void = () => undefined
+  viewMode,
+} = workspace.state
 const editorPaneRef = useTemplateRef<InstanceType<typeof EditorPane>>('editorPane')
 const previewPaneRef = useTemplateRef<InstanceType<typeof PreviewPane>>('previewPane')
-const availableModes = computed<ViewMode[]>(() =>
-  isMobile.value ? ['editor', 'preview'] : ['editor', 'split', 'preview'],
-)
 
-// Note: restoreStoredDraft must be called after useDocumentSession initializes restoreDraft.
-const { clearDraft, restoreStoredDraft } = useWebDraftPersistence({
-  content,
-  displayName,
-  isDesktop,
-  isDirty,
-  restoreDraft,
-})
-
-// Computed body classes for view mode and theme
-const bodyClasses = computed(() => ({
-  'is-mobile': isMobile.value,
-  'view-editor': viewMode.value === 'editor',
-  'view-preview': viewMode.value === 'preview',
-  'view-split': viewMode.value === 'split',
-}))
-
-// Watch theme and apply to document
 watch(
-  theme,
-  (newTheme) => {
-    document.documentElement.setAttribute('data-theme', newTheme)
+  editorPaneRef,
+  (editorPane) => {
+    if (!editorPane) {
+      return
+    }
+
+    workspace.attach.editor({
+      focus: () => editorPane.focus(),
+      focusAtOffset: (offset) => editorPane.focusAtOffset(offset),
+      focusFindQuery: () => editorPane.focusFindQuery(),
+      getScrollState: () => editorPane.getScrollState(),
+      replaceAllContent: (content) => editorPane.replaceAllContent(content),
+      replaceRange: (start, end, replacement) => editorPane.replaceRange(start, end, replacement),
+      setSelectionRange: (start, end) => editorPane.setSelectionRange(start, end),
+    })
   },
   { immediate: true },
 )
 
-function closeExamples(): void {
-  isExamplesModalOpen.value = false
-}
-
-function focusFindQuery(): void {
-  void nextTick(() => {
-    editorPaneRef.value?.focusFindQuery()
-  })
-}
-
-function getOffsetForLine(contentValue: string, lineNumber: number): number {
-  if (lineNumber <= 0) return 0
-
-  let currentLine = 0
-
-  for (let index = 0; index < contentValue.length; index += 1) {
-    if (contentValue[index] === '\n') {
-      currentLine += 1
-      if (currentLine === lineNumber) {
-        return index + 1
-      }
+watch(
+  previewPaneRef,
+  (previewPane) => {
+    if (!previewPane) {
+      return
     }
-  }
 
-  return contentValue.length
-}
-
-function handleContentUpdate(value: string): void {
-  updateContent(value)
-}
+    workspace.attach.preview({
+      scrollToSourceOffset: (offset) => previewPane.scrollToSourceOffset(offset),
+    })
+  },
+  { immediate: true },
+)
 
 function handleEditorScroll(scrollState: EditorScrollPayload): void {
-  syncPreviewToEditorPosition(scrollState)
-}
-
-function handleExampleSelect(example: Example): void {
-  loadExample(example)
-  // Focus the editor after loading
-  setTimeout(() => {
-    editorPaneRef.value?.focus()
-  }, 0)
+  workspace.editor.syncPreviewToEditorPosition(scrollState)
 }
 
 function handleExportHtml(): void {
-  void exportHtml().catch((error: unknown) => {
+  void workspace.export.html().catch((error: unknown) => {
     console.error('Failed to export HTML:', error)
   })
 }
 
 function handleExportPdf(): void {
-  void exportPdf().catch((error: unknown) => {
+  void workspace.export.pdf().catch((error: unknown) => {
     console.error('Failed to export PDF:', error)
   })
 }
 
-function handleFindClose(): void {
-  closeFindReplace()
-  editorPaneRef.value?.focus()
-}
-
-function handleFindQueryUpdate(value: string): void {
-  setQuery(value)
-}
-
-function handleFindReplaceShortcut(): void {
-  openReplacePanel()
-  focusFindQuery()
-}
-
-function handleFindShortcut(): void {
-  openFindPanel()
-  focusFindQuery()
-}
-
-function handleGlobalKeydown(event: KeyboardEvent): void {
-  if (event.defaultPrevented) {
-    return
-  }
-
-  const normalizedKey = event.key.toLowerCase()
-  const hasCommandModifier = event.metaKey || event.ctrlKey
-
-  if (hasCommandModifier && normalizedKey === 'f') {
-    event.preventDefault()
-    handleFindShortcut()
-    return
-  }
-
-  if (hasCommandModifier && normalizedKey === 'h') {
-    event.preventDefault()
-    handleFindReplaceShortcut()
-    return
-  }
-
-  if (!isFindReplaceOpen.value) {
-    return
-  }
-
-  if ((hasCommandModifier && normalizedKey === 'g') || event.key === 'F3') {
-    event.preventDefault()
-    if (event.shiftKey) {
-      findPrevious()
-      return
-    }
-
-    findNext()
-  }
-}
-
 function handleInstall(): void {
-  void install().catch((error: unknown) => {
+  void workspace.toolbar.install().catch((error: unknown) => {
     console.error('Failed to trigger web app install:', error)
   })
 }
 
-function handlePreviewJump(offset: number): void {
-  if (isMobile.value || viewMode.value !== 'split') return
-
-  void editorPaneRef.value?.focusAtOffset(offset)
-}
-
-function handlePwaBannerDismiss(): void {
-  if (needRefresh.value) {
-    dismissRefreshPrompt()
-    return
-  }
-
-  dismissOfflineReady()
-}
-
-function handleRenderDiagrams(container: HTMLElement): void {
-  renderMermaidDiagrams(container)
-}
-
-async function handleReplaceAll(): Promise<void> {
-  const replacementPlan = prepareReplaceAll()
-  if (!replacementPlan) {
-    return
-  }
-
-  await editorPaneRef.value?.replaceAllContent(replacementPlan.nextContent)
-  commitReplacement(replacementPlan.nextActiveIndex)
-  editorPaneRef.value?.focus()
-}
-
-async function handleReplaceCurrent(): Promise<void> {
-  const replacementPlan = prepareReplaceCurrent()
-  if (!replacementPlan) {
-    return
-  }
-
-  await editorPaneRef.value?.replaceRange(
-    replacementPlan.match.index,
-    replacementPlan.match.end,
-    replacementPlan.replacement,
-  )
-  commitReplacement(replacementPlan.nextActiveIndex)
-  editorPaneRef.value?.focus()
-}
-
 function handleStartNewDocument(): void {
-  void startNewDocument()
-    .then(() => {
-      if (!content.value) {
-        clearDraft()
-      }
-    })
-    .catch((error: unknown) => {
-      console.error('Failed to start new document:', error)
-    })
-}
-
-async function handleThemeChange(request: ThemeChangeRequest): Promise<void> {
-  if (request.theme === theme.value) return
-
-  await transitionTheme(request.theme, setTheme, {
-    origin: request.origin,
+  void workspace.document.startNew().catch((error: unknown) => {
+    console.error('Failed to start new document:', error)
   })
 }
 
-// Actions
-function handleViewModeChange(mode: ViewMode): void {
-  setViewMode(mode)
-}
-
-function openExamples(): void {
-  isExamplesModalOpen.value = true
-}
-
-function syncFindSelection(): void {
-  const match = activeMatch.value
-  if (!match) {
-    return
-  }
-
-  void nextTick(() => {
-    editorPaneRef.value?.setSelectionRange(match.index, match.end)
-  })
-}
-
-function syncPreviewToEditorPosition(scrollState?: EditorScrollPayload | null): void {
-  if (isMobile.value || viewMode.value !== 'split') return
-
-  const effectiveScrollState = scrollState ?? editorPaneRef.value?.getScrollState()
-  if (!effectiveScrollState) return
-
-  const topLine = Math.max(
-    0,
-    Math.floor(effectiveScrollState.scrollTop / effectiveScrollState.lineHeight),
-  )
-  const sourceOffset = getOffsetForLine(content.value, topLine)
-  previewPaneRef.value?.scrollToSourceOffset(sourceOffset)
-}
-
-function syncViewport(): void {
-  if (typeof window === 'undefined') return
-
-  const nextIsMobile = window.innerWidth <= mobileBreakpoint
-  isMobile.value = nextIsMobile
-
-  if (nextIsMobile && viewMode.value === 'split') {
-    setViewMode('editor')
-  }
-}
-
-onMounted(async () => {
-  syncViewport()
-  window.addEventListener('resize', syncViewport)
-  window.addEventListener('keydown', handleGlobalKeydown)
-  startUpdateChecks()
-  await restoreStoredDraft()
-
-  const onAppCommand = desktop.value?.commands?.onAppCommand
-  if (onAppCommand) {
-    removeDesktopCommandListener = onAppCommand((command: AppCommand) => {
-      void handleDesktopCommand(command).catch((error: unknown) => {
-        console.error('Failed to handle desktop app command:', error)
-      })
-    })
-  } else {
-    removeDesktopCommandListener = () => undefined
-  }
+onMounted(() => {
+  void workspace.system.start()
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', syncViewport)
-  window.removeEventListener('keydown', handleGlobalKeydown)
-  removeDesktopCommandListener()
-  stopUpdateChecks()
+  workspace.system.stop()
 })
-
-watch(
-  () => [content.value, isMobile.value, sourceMap.value, viewMode.value],
-  async () => {
-    await nextTick()
-    syncPreviewToEditorPosition()
-  },
-  { deep: true },
-)
-
-watch(requestSelectionSync, () => {
-  syncFindSelection()
-})
-
-async function handleDesktopCommand(command: AppCommand): Promise<void> {
-  switch (command) {
-    case 'document:exportHtml':
-      await exportHtml()
-      return
-    case 'document:exportPdf':
-      if (canExportPdf.value) {
-        await exportPdf()
-      }
-      return
-    case 'editor:find':
-      handleFindShortcut()
-      return
-    case 'editor:replace':
-      handleFindReplaceShortcut()
-      return
-    case 'update:check':
-      await checkNow()
-      return
-    default:
-      await handleAppCommand(command)
-  }
-}
 </script>
 
 <template>
@@ -471,15 +135,15 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
       :theme="theme"
       :is-copied="isCopied"
       @install="handleInstall"
-      @open-document="openDocument"
-      @update:view-mode="handleViewModeChange"
-      @update:theme="handleThemeChange"
-      @open-examples="openExamples"
+      @open-document="workspace.document.open"
+      @update:view-mode="workspace.editor.setViewMode"
+      @update:theme="workspace.editor.setTheme"
+      @open-examples="workspace.examples.open"
       @clear="handleStartNewDocument"
-      @copy="copyContent"
+      @copy="workspace.toolbar.copy"
       @export-html="handleExportHtml"
       @export-pdf="handleExportPdf"
-      @save-document="saveDocument"
+      @save-document="workspace.document.save"
     />
 
     <Transition name="banner-slide">
@@ -488,8 +152,8 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
         :status="bannerStatus"
         :current-version="updateInfo?.currentVersion"
         :latest-version="updateInfo?.latestVersion"
-        @dismiss="dismissUpdateBanner"
-        @download="downloadUpdate"
+        @dismiss="workspace.toolbar.dismissUpdateBanner"
+        @download="workspace.toolbar.downloadUpdate"
       />
     </Transition>
 
@@ -497,8 +161,8 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
       <PwaBanner
         v-if="showPwaBanner"
         :status="pwaBannerStatus"
-        @dismiss="handlePwaBannerDismiss"
-        @refresh="updateApp"
+        @dismiss="workspace.toolbar.dismissPwaBanner"
+        @refresh="workspace.toolbar.updateApp"
       />
     </Transition>
 
@@ -515,18 +179,18 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
         :query="query"
         :replace-text="replaceText"
         :show-replace="showReplace"
-        @find:close="handleFindClose"
-        @find:next="findNext"
-        @find:previous="findPrevious"
-        @find:replace-all="handleReplaceAll"
-        @find:replace-current="handleReplaceCurrent"
-        @request-find="handleFindShortcut"
-        @request-replace="handleFindReplaceShortcut"
+        @find:close="workspace.find.close"
+        @find:next="workspace.find.next"
+        @find:previous="workspace.find.previous"
+        @find:replace-all="workspace.find.replaceAll"
+        @find:replace-current="workspace.find.replaceCurrent"
+        @request-find="workspace.find.open"
+        @request-replace="workspace.find.openReplace"
         @scroll="handleEditorScroll"
-        @update:content="handleContentUpdate"
-        @update:match-case="setMatchCase"
-        @update:query="handleFindQueryUpdate"
-        @update:replace-text="setReplaceText"
+        @update:content="workspace.editor.updateContent"
+        @update:match-case="workspace.find.setMatchCase"
+        @update:query="workspace.find.setQuery"
+        @update:replace-text="workspace.find.setReplaceText"
       />
       <PreviewPane
         ref="previewPane"
@@ -534,8 +198,8 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
         :source-map="sourceMap"
         :theme="theme"
         :word-count="stats.words"
-        @jump-to-offset="handlePreviewJump"
-        @render-diagrams="handleRenderDiagrams"
+        @jump-to-offset="workspace.preview.jumpToOffset"
+        @render-diagrams="workspace.preview.renderDiagrams"
       />
     </main>
 
@@ -549,8 +213,8 @@ async function handleDesktopCommand(command: AppCommand): Promise<void> {
 
     <ExamplesModal
       :is-open="isExamplesModalOpen"
-      @close="closeExamples"
-      @select="handleExampleSelect"
+      @close="workspace.examples.close"
+      @select="workspace.editor.loadExample"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Introduces the initial `useEditorWorkspaceController()` boundary to extract orchestration logic from `MarkdownStudioView.vue`. The controller owns workflow coordination (keyboard shortcuts, view mode sync, find/replace, PWA, document session, update checking) while the view becomes a thin composition surface that wires the controller to Vue components via adapter interfaces. Follow-up issues can deepen the controller without re-introducing view-level coordination seams.

RFC: #46

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [x] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Behavior preserved — editor/preview panes, find/replace, keyboard shortcuts (Cmd+F, Cmd+H, Cmd+G), view mode switching, draft restoration, PWA and update banners all function identically.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

Closes #47

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
