### PR TITLE
refactor(markdown): internalize workspace controller lifecycle

### DIFF
--- a/.changeset/workspace-controller-lifecycle.md
+++ b/.changeset/workspace-controller-lifecycle.md
@@ -1,0 +1,13 @@
+---
+"markdown-studio": patch
+"@markdown-studio/desktop": patch
+---
+
+Internalize workspace controller lifecycle
+- Move `start()`/`stop()` calls from MarkdownStudioView.vue into `useEditorWorkspaceController` via `onMounted`/`onUnmounted`
+- Harden lifecycle with idempotency guards (`isStarted` flag) and comprehensive error-path cleanup
+- Replace `setTimeout(0)` with `nextTick()` for deterministic editor focus after loading examples
+- Capture editor adapter references before async operations to prevent TOCTOU issues
+- Add null-detach pattern for adapter refs when components unmount
+- Extract shared types to `types/common.ts` with barrel re-exports
+- Add tests for auto-start lifecycle, desktop command subscription cleanup, and idempotency

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -185,6 +185,23 @@ describe('useEditorWorkspaceController', () => {
     wrapper.unmount()
   })
 
+  it('loads an example and restores editor focus after the update flushes', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+
+    await workspace.editor.loadExample({
+      content: '# Example content',
+      desc: 'Example description',
+      title: 'Example title',
+    })
+
+    expect(workspace.state.content.value).toBe('# Example content')
+    expect(editor.focus).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
   it('collapses split view to editor mode on mobile viewport changes', async () => {
     const { workspace, wrapper } = await mountWorkspace()
 
@@ -209,15 +226,53 @@ describe('useEditorWorkspaceController', () => {
     )
 
     const { workspace, wrapper } = await mountWorkspace()
-
-    await workspace.system.start()
     await flushPromises()
 
     expect(workspace.state.content.value).toBe('# Restored draft')
     expect(workspace.state.displayName.value).toBe('notes.md')
     expect(workspace.state.isDirty.value).toBe(true)
 
-    workspace.system.stop()
     wrapper.unmount()
+  })
+
+  it('auto-starts on mount and stops desktop command subscriptions on unmount', async () => {
+    const removeDesktopCommandListener = vi.fn()
+    const onAppCommand = vi.fn(() => removeDesktopCommandListener)
+
+    appWindow.desktop = {
+      commands: {
+        onAppCommand,
+      },
+      documents: {
+        open: async () => null,
+        save: async () => null,
+        saveAs: async () => null,
+      },
+      editing: {
+        insertText: async () => undefined,
+      },
+      exports: {
+        exportHtml: async () => null,
+        exportPdf: async () => null,
+      },
+      isDesktop: true,
+      shell: {
+        openExternal: async () => undefined,
+      },
+    }
+
+    const { workspace, wrapper } = await mountWorkspace()
+    await flushPromises()
+
+    expect(onAppCommand).toHaveBeenCalledTimes(1)
+    expect(workspace.state.isDesktop.value).toBe(true)
+
+    // Verify idempotency: calling start() again should not re-register listeners
+    await workspace.system.start()
+    expect(onAppCommand).toHaveBeenCalledTimes(1) // Still only called once from the first start
+
+    wrapper.unmount()
+
+    expect(removeDesktopCommandListener).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -1,6 +1,6 @@
 import type { AppCommand } from '@markdown-studio/desktop-contract/types'
 
-import { computed, nextTick, shallowRef, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, shallowRef, watch } from 'vue'
 
 import { useDesktop } from '@/composables/useDesktop'
 import { usePwa } from '@/composables/usePwa'
@@ -36,6 +36,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   const previewPane = shallowRef<null | PreviewPaneAdapter>(null)
   const isExamplesModalOpen = shallowRef(false)
   const isMobile = shallowRef(false)
+  const isStarted = shallowRef(false)
 
   const {
     content,
@@ -166,18 +167,17 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       await nextTick()
       syncPreviewToEditorPosition()
     },
-    { deep: true },
   )
 
   watch(requestSelectionSync, () => {
     syncFindSelection()
   })
 
-  function attachEditor(adapter: EditorPaneAdapter): void {
+  function attachEditor(adapter: EditorPaneAdapter | null): void {
     editorPane.value = adapter
   }
 
-  function attachPreview(adapter: PreviewPaneAdapter): void {
+  function attachPreview(adapter: null | PreviewPaneAdapter): void {
     previewPane.value = adapter
   }
 
@@ -286,9 +286,10 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       return
     }
 
-    await editorPane.value?.replaceAllContent(replacementPlan.nextContent)
+    const editorAdapter = editorPane.value
+    await editorAdapter?.replaceAllContent(replacementPlan.nextContent)
     commitReplacement(replacementPlan.nextActiveIndex)
-    editorPane.value?.focus()
+    editorAdapter?.focus()
   }
 
   async function replaceCurrent(): Promise<void> {
@@ -297,13 +298,14 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       return
     }
 
-    await editorPane.value?.replaceRange(
+    const editorAdapter = editorPane.value
+    await editorAdapter?.replaceRange(
       replacementPlan.match.index,
       replacementPlan.match.end,
       replacementPlan.replacement,
     )
     commitReplacement(replacementPlan.nextActiveIndex)
-    editorPane.value?.focus()
+    editorAdapter?.focus()
   }
 
   async function startNew(): Promise<void> {
@@ -323,9 +325,8 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
 
   async function loadWorkspaceExample(example: Parameters<typeof loadExample>[0]): Promise<void> {
     loadExample(example)
-    setTimeout(() => {
-      editorPane.value?.focus()
-    }, 0)
+    await nextTick()
+    editorPane.value?.focus()
   }
 
   async function jumpToOffset(offset: number): Promise<void> {
@@ -335,29 +336,48 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   }
 
   async function start(): Promise<void> {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || isStarted.value === true) {
       return
     }
 
-    syncViewport(window.innerWidth)
-    window.addEventListener('resize', handleWindowResize)
-    window.addEventListener('keydown', handleGlobalKeydown)
-    startUpdateChecks()
-    await restoreStoredDraft()
+    // Set flag immediately to prevent concurrent start attempts
+    isStarted.value = true
 
-    const onAppCommand = desktop.value?.commands?.onAppCommand
-    if (onAppCommand) {
-      removeDesktopCommandListener = onAppCommand((command: AppCommand) => {
-        void handleDesktopCommand(command).catch((error: unknown) => {
-          console.error('Failed to handle desktop app command:', error)
+    try {
+      window.addEventListener('resize', handleWindowResize)
+      window.addEventListener('keydown', handleGlobalKeydown)
+      startUpdateChecks()
+      syncViewport(window.innerWidth)
+      await restoreStoredDraft()
+
+      const onAppCommand = desktop.value?.commands?.onAppCommand
+      if (onAppCommand) {
+        removeDesktopCommandListener = onAppCommand((command: AppCommand) => {
+          void handleDesktopCommand(command).catch((error: unknown) => {
+            console.error('Failed to handle desktop app command:', error)
+          })
         })
-      })
-    } else {
+      } else {
+        removeDesktopCommandListener = () => undefined
+      }
+    } catch (error) {
+      window.removeEventListener('resize', handleWindowResize)
+      window.removeEventListener('keydown', handleGlobalKeydown)
+      removeDesktopCommandListener()
       removeDesktopCommandListener = () => undefined
+      stopUpdateChecks()
+      isStarted.value = false
+      throw error
     }
   }
 
   function stop(): void {
+    if (isStarted.value !== true) {
+      return
+    }
+
+    isStarted.value = false
+
     if (typeof window !== 'undefined') {
       window.removeEventListener('resize', handleWindowResize)
       window.removeEventListener('keydown', handleGlobalKeydown)
@@ -428,6 +448,14 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   async function installApp(): Promise<void> {
     await install()
   }
+
+  onMounted(() => {
+    void start()
+  })
+
+  onUnmounted(() => {
+    stop()
+  })
 
   return {
     attach: {

--- a/packages/app/src/features/markdown/types/common.ts
+++ b/packages/app/src/features/markdown/types/common.ts
@@ -1,0 +1,22 @@
+export interface EditorStats {
+  chars: number
+  diagrams: number
+  lines: number
+  words: number
+}
+
+export interface Example {
+  content: string
+  desc: string
+  title: string
+}
+
+export interface MarkdownSourceMapEntry {
+  end: number
+  id: string
+  start: number
+  type: string
+}
+
+export type Theme = 'dark' | 'light'
+export type ViewMode = 'editor' | 'preview' | 'split'

--- a/packages/app/src/features/markdown/types/index.ts
+++ b/packages/app/src/features/markdown/types/index.ts
@@ -1,25 +1,4 @@
-export interface EditorStats {
-  chars: number
-  diagrams: number
-  lines: number
-  words: number
-}
-
-export interface Example {
-  content: string
-  desc: string
-  title: string
-}
-
-export interface MarkdownSourceMapEntry {
-  end: number
-  id: string
-  start: number
-  type: string
-}
-
-export type Theme = 'dark' | 'light'
-export type ViewMode = 'editor' | 'preview' | 'split'
+export type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './common'
 
 export type {
   EditorPaneAdapter,

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -2,7 +2,7 @@ import type { AppCommand } from '@markdown-studio/desktop-contract/types'
 import type { ComputedRef, Ref, ShallowRef } from 'vue'
 
 import type { FindMatch } from '../composables/useFindReplace'
-import type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './index'
+import type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './common'
 
 /**
  * Imperative capabilities exposed by the editor pane.
@@ -38,8 +38,8 @@ export interface EditorScrollPayload {
 
 export interface EditorWorkspaceController {
   attach: {
-    editor(adapter: EditorPaneAdapter): void
-    preview(adapter: PreviewPaneAdapter): void
+    editor(adapter: EditorPaneAdapter | null): void
+    preview(adapter: null | PreviewPaneAdapter): void
   }
   document: {
     handleAppCommand(command: AppCommand): Promise<void>

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
+import { useTemplateRef, watch } from 'vue'
 
 import type { EditorScrollPayload } from '@/features/markdown/types'
 
@@ -54,6 +54,7 @@ watch(
   editorPaneRef,
   (editorPane) => {
     if (!editorPane) {
+      workspace.attach.editor(null)
       return
     }
 
@@ -74,6 +75,7 @@ watch(
   previewPaneRef,
   (previewPane) => {
     if (!previewPane) {
+      workspace.attach.preview(null)
       return
     }
 
@@ -111,14 +113,6 @@ function handleStartNewDocument(): void {
     console.error('Failed to start new document:', error)
   })
 }
-
-onMounted(() => {
-  void workspace.system.start()
-})
-
-onUnmounted(() => {
-  workspace.system.stop()
-})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

This PR internalizes the workspace controller's lifecycle management (`start()`/`stop()`) into the `useEditorWorkspaceController` composable via Vue's `onMounted`/`onUnmounted` hooks, removing that responsibility from the `MarkdownStudioView.vue` component. This hardens the lifecycle with idempotency guards, comprehensive error-path cleanup, and deterministic focus restoration.

RFC: #46 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [x] Test

## Screenshots

<!-- No UI changes - internal refactoring only -->
| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified lifecycle cleanup in component unmount scenarios

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

Closes #48

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)