### PR TITLE
refactor(markdown): move find/replace orchestration into controller

### DIFF
--- a/.changeset/find-replace-controller-refactor.md
+++ b/.changeset/find-replace-controller-refactor.md
@@ -1,0 +1,12 @@
+---
+"markdown-studio": patch
+"@markdown-studio/desktop": patch
+---
+
+Refactor find/replace workflow into editor workspace controller
+
+- Move find/replace orchestration behind `useEditorWorkspaceController()` boundary
+- Replace individual state exports with unified `findState` computed property
+- Add `workspace.find.dispatch()` action pattern for all find/replace operations
+- Remove view-level coordination between composables and component refs
+- Reduce coupling between MarkdownStudioView, useFindReplace, and imperative pane calls

--- a/packages/app/src/features/markdown/components/EditorPane.vue
+++ b/packages/app/src/features/markdown/components/EditorPane.vue
@@ -5,49 +5,38 @@ import type { AppWindow } from '@/browser-window'
 
 import { insertTextAtSelection } from '@/utils/insertTextAtSelection'
 
-import type { FindMatch } from '../composables/useFindReplace'
-import type { EditorScrollPayload } from '../types'
+import type {
+  EditorScrollPayload,
+  EditorWorkspaceFindAction,
+  EditorWorkspaceFindState,
+} from '../types'
 
 import FindReplaceBar from './FindReplaceBar.vue'
 import MatchOverlay from './MatchOverlay.vue'
 
 interface Props {
-  activeMatchIndex?: number
   content: string
-  findOpen?: boolean
+  findState?: EditorWorkspaceFindState
   lineCount: number
-  matchCase?: boolean
-  matchCount?: number
-  matches?: FindMatch[]
-  query?: string
-  replaceText?: string
-  showReplace?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  activeMatchIndex: -1,
-  findOpen: false,
-  matchCase: false,
-  matchCount: 0,
-  matches: () => [],
-  query: '',
-  replaceText: '',
-  showReplace: false,
+  findState: () => ({
+    activeMatchIndex: -1,
+    isOpen: false,
+    matchCase: false,
+    matchCount: 0,
+    matches: [],
+    query: '',
+    replaceText: '',
+    showReplace: false,
+  }),
 })
 
 const emit = defineEmits<{
-  'find:close': []
-  'find:next': []
-  'find:previous': []
-  'find:replace-all': []
-  'find:replace-current': []
-  'request-find': []
-  'request-replace': []
+  'find-action': [action: EditorWorkspaceFindAction]
   scroll: [payload: EditorScrollPayload]
   'update:content': [value: string]
-  'update:match-case': [value: boolean]
-  'update:query': [value: string]
-  'update:replace-text': [value: string]
 }>()
 
 const editorRef = useTemplateRef<HTMLTextAreaElement>('editor')
@@ -121,14 +110,14 @@ function handleKeydown(event: KeyboardEvent): void {
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
     event.preventDefault()
     event.stopPropagation()
-    emit('request-find')
+    emit('find-action', { type: 'open' })
     return
   }
 
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'h') {
     event.preventDefault()
     event.stopPropagation()
-    emit('request-replace')
+    emit('find-action', { type: 'open-replace' })
     return
   }
 
@@ -259,29 +248,29 @@ watch(
     </div>
 
     <FindReplaceBar
-      v-if="findOpen"
+      v-if="findState.isOpen"
       ref="findReplaceBar"
-      :active-match-number="activeMatchIndex >= 0 ? activeMatchIndex + 1 : 0"
-      :match-case="matchCase"
-      :match-count="matchCount"
-      :query="query"
-      :replace-text="replaceText"
-      :show-replace="showReplace"
-      @close="emit('find:close')"
-      @next="emit('find:next')"
-      @previous="emit('find:previous')"
-      @replace-all="emit('find:replace-all')"
-      @replace-current="emit('find:replace-current')"
-      @update:match-case="emit('update:match-case', $event)"
-      @update:query="emit('update:query', $event)"
-      @update:replace-text="emit('update:replace-text', $event)"
+      :active-match-number="findState.activeMatchIndex >= 0 ? findState.activeMatchIndex + 1 : 0"
+      :match-case="findState.matchCase"
+      :match-count="findState.matchCount"
+      :query="findState.query"
+      :replace-text="findState.replaceText"
+      :show-replace="findState.showReplace"
+      @close="emit('find-action', { type: 'close' })"
+      @next="emit('find-action', { type: 'next' })"
+      @previous="emit('find-action', { type: 'previous' })"
+      @replace-all="emit('find-action', { type: 'replace-all' })"
+      @replace-current="emit('find-action', { type: 'replace-current' })"
+      @update:match-case="emit('find-action', { type: 'set-match-case', value: $event })"
+      @update:query="emit('find-action', { type: 'set-query', value: $event })"
+      @update:replace-text="emit('find-action', { type: 'set-replace-text', value: $event })"
     />
 
     <div class="editor-body">
       <MatchOverlay
-        :active-match-index="activeMatchIndex"
+        :active-match-index="findState.activeMatchIndex"
         :content="content"
-        :matches="findOpen ? matches : []"
+        :matches="findState.isOpen ? findState.matches : []"
         :scrollbar-width="scrollbarWidth"
         :scroll-top="scrollTop"
       />

--- a/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
@@ -9,16 +9,18 @@ function mountEditorPane(overrides: Record<string, unknown> = {}) {
   return mount(EditorPane, {
     attachTo: document.body,
     props: {
-      activeMatchIndex: -1,
       content: 'line 1\nline 2\nline 3\nline 4\nline 5\nline 6',
-      findOpen: false,
+      findState: {
+        activeMatchIndex: -1,
+        isOpen: false,
+        matchCase: false,
+        matchCount: 0,
+        matches: [],
+        query: '',
+        replaceText: '',
+        showReplace: false,
+      },
       lineCount: 6,
-      matchCase: false,
-      matchCount: 0,
-      matches: [],
-      query: '',
-      replaceText: '',
-      showReplace: false,
       ...overrides,
     },
   })
@@ -82,23 +84,25 @@ describe('EditorPane', () => {
     await wrapper.get('textarea').trigger('keydown', { ctrlKey: true, key: 'f' })
     await wrapper.get('textarea').trigger('keydown', { key: 'h', metaKey: true })
 
-    expect(wrapper.emitted('request-find')).toHaveLength(1)
-    expect(wrapper.emitted('request-replace')).toHaveLength(1)
+    expect(wrapper.emitted('find-action')).toEqual([[{ type: 'open' }], [{ type: 'open-replace' }]])
   })
 
   it('renders the inline find UI and emits navigation and close actions', async () => {
     const wrapper = mountEditorPane({
-      activeMatchIndex: 1,
-      findOpen: true,
-      matchCount: 3,
-      matches: [
-        { end: 4, index: 0, length: 4 },
-        { end: 10, index: 6, length: 4 },
-        { end: 16, index: 12, length: 4 },
-      ],
-      query: 'line',
-      replaceText: 'row',
-      showReplace: true,
+      findState: {
+        activeMatchIndex: 1,
+        isOpen: true,
+        matchCase: false,
+        matchCount: 3,
+        matches: [
+          { end: 4, index: 0, length: 4 },
+          { end: 10, index: 6, length: 4 },
+          { end: 16, index: 12, length: 4 },
+        ],
+        query: 'line',
+        replaceText: 'row',
+        showReplace: true,
+      },
     })
 
     expect(wrapper.text()).toContain('2 of 3')
@@ -112,17 +116,25 @@ describe('EditorPane', () => {
     await queryInput!.trigger('keydown', { key: 'Enter', shiftKey: true })
     await replaceInput!.trigger('keydown', { key: 'Escape' })
 
-    expect(wrapper.emitted('find:next')).toHaveLength(1)
-    expect(wrapper.emitted('find:previous')).toHaveLength(1)
-    expect(wrapper.emitted('find:close')).toHaveLength(1)
+    expect(wrapper.emitted('find-action')).toEqual([
+      [{ type: 'next' }],
+      [{ type: 'previous' }],
+      [{ type: 'close' }],
+    ])
   })
 
   it('disables replace actions when there are no matches', () => {
     const wrapper = mountEditorPane({
-      findOpen: true,
-      matchCount: 0,
-      query: 'missing',
-      showReplace: true,
+      findState: {
+        activeMatchIndex: -1,
+        isOpen: true,
+        matchCase: false,
+        matchCount: 0,
+        matches: [],
+        query: 'missing',
+        replaceText: '',
+        showReplace: true,
+      },
     })
 
     const replaceButtons = wrapper
@@ -237,16 +249,21 @@ describe('EditorPane', () => {
 
   it('does not move focus away from the editor when clicking find controls', async () => {
     const wrapper = mountEditorPane({
-      activeMatchIndex: 0,
       content: 'item one item two',
-      findOpen: true,
+      findState: {
+        activeMatchIndex: 0,
+        isOpen: true,
+        matchCase: false,
+        matchCount: 2,
+        matches: [
+          { end: 4, index: 0, length: 4 },
+          { end: 13, index: 9, length: 4 },
+        ],
+        query: 'item',
+        replaceText: '',
+        showReplace: false,
+      },
       lineCount: 1,
-      matchCount: 2,
-      matches: [
-        { end: 4, index: 0, length: 4 },
-        { end: 13, index: 9, length: 4 },
-      ],
-      query: 'item',
     })
 
     const textarea = wrapper.get('textarea').element as HTMLTextAreaElement

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -7,6 +7,7 @@ import type { AppWindow } from '@/browser-window'
 import type {
   EditorPaneAdapter,
   EditorWorkspaceController,
+  EditorWorkspaceFindAction,
   PreviewPaneAdapter,
 } from '@/features/markdown/types'
 
@@ -111,8 +112,8 @@ describe('useEditorWorkspaceController', () => {
     )
     await nextTick()
 
-    expect(workspace.state.isFindReplaceOpen.value).toBe(true)
-    expect(workspace.state.showReplace.value).toBe(true)
+    expect(workspace.find.state.value.isOpen).toBe(true)
+    expect(workspace.find.state.value.showReplace).toBe(true)
     expect(editor.focusFindQuery).toHaveBeenCalledTimes(1)
 
     wrapper.unmount()
@@ -124,14 +125,14 @@ describe('useEditorWorkspaceController', () => {
     workspace.attach.editor(editor)
 
     workspace.editor.updateContent('cat dog cat')
-    workspace.find.setQuery('cat')
-    workspace.find.setReplaceText('fox')
+    await workspace.find.dispatch({ type: 'set-query', value: 'cat' })
+    await workspace.find.dispatch({ type: 'set-replace-text', value: 'fox' })
 
-    await workspace.find.replaceCurrent()
+    await workspace.find.dispatch({ type: 'replace-current' })
 
     expect(editor.replaceRange).toHaveBeenCalledWith(0, 3, 'fox')
     expect(editor.focus).toHaveBeenCalledTimes(1)
-    expect(workspace.state.activeMatchIndex.value).toBe(0)
+    expect(workspace.find.state.value.activeMatchIndex).toBe(0)
 
     wrapper.unmount()
   })
@@ -181,6 +182,38 @@ describe('useEditorWorkspaceController', () => {
     workspace.editor.setViewMode('editor')
     await workspace.preview.jumpToOffset(24)
     expect(editor.focusAtOffset).not.toHaveBeenCalled()
+
+    workspace.editor.setViewMode('split')
+    workspace.system.handleViewportResize(640)
+    await workspace.preview.jumpToOffset(32)
+    expect(editor.focusAtOffset).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('handles all supported find actions without throwing', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+
+    workspace.editor.updateContent('cat dog cat')
+
+    const actions: EditorWorkspaceFindAction[] = [
+      { type: 'open' },
+      { type: 'open-replace' },
+      { type: 'close' },
+      { type: 'next' },
+      { type: 'previous' },
+      { type: 'set-query', value: 'cat' },
+      { type: 'set-match-case', value: true },
+      { type: 'set-replace-text', value: 'fox' },
+      { type: 'replace-current' },
+      { type: 'replace-all' },
+    ]
+
+    for (const action of actions) {
+      await expect(workspace.find.dispatch(action)).resolves.toBeUndefined()
+    }
 
     wrapper.unmount()
   })

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -12,6 +12,7 @@ import type {
   EditorPaneAdapter,
   EditorScrollPayload,
   EditorWorkspaceController,
+  EditorWorkspaceFindAction,
   PreviewPaneAdapter,
   ThemeChangeRequest,
 } from '../types/workspace'
@@ -149,6 +150,16 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     'view-editor': viewMode.value === 'editor',
     'view-preview': viewMode.value === 'preview',
     'view-split': viewMode.value === 'split',
+  }))
+  const findState = computed(() => ({
+    activeMatchIndex: activeMatchIndex.value,
+    isOpen: isFindReplaceOpen.value,
+    matchCase: matchCase.value,
+    matchCount: matchCount.value,
+    matches: matches.value,
+    query: query.value,
+    replaceText: replaceText.value,
+    showReplace: showReplace.value,
   }))
 
   let removeDesktopCommandListener: () => void = () => undefined
@@ -431,7 +442,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     }
   }
 
-  function closeFind(): void {
+  function closeFindPanel(): void {
     closeFindReplace()
     editorPane.value?.focus()
   }
@@ -503,20 +514,43 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       },
     },
     find: {
-      close: closeFind,
-      next: findNext,
-      open: openFindPanel,
-      openReplace: openReplacePanel,
-      previous: findPrevious,
-      async replaceAll(): Promise<void> {
-        await replaceAll()
+      async dispatch(action: EditorWorkspaceFindAction): Promise<void> {
+        switch (action.type) {
+          case 'close':
+            closeFindPanel()
+            return
+          case 'next':
+            findNext()
+            return
+          case 'open':
+            openFindPanel()
+            return
+          case 'open-replace':
+            openReplacePanel()
+            return
+          case 'previous':
+            findPrevious()
+            return
+          case 'replace-all':
+            await replaceAll()
+            return
+          case 'replace-current':
+            await replaceCurrent()
+            return
+          case 'set-match-case':
+            setMatchCase(action.value)
+            return
+          case 'set-query':
+            setQuery(action.value)
+            return
+          case 'set-replace-text':
+            setReplaceText(action.value)
+            return
+          default:
+            action satisfies never
+        }
       },
-      async replaceCurrent(): Promise<void> {
-        await replaceCurrent()
-      },
-      setMatchCase,
-      setQuery,
-      setReplaceText,
+      state: findState,
     },
     preview: {
       async jumpToOffset(offset: number): Promise<void> {
@@ -527,7 +561,6 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       },
     },
     state: {
-      activeMatchIndex,
       availableModes,
       bannerStatus,
       bodyClasses,
@@ -542,21 +575,14 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       isDesktop,
       isDirty,
       isExamplesModalOpen,
-      isFindReplaceOpen,
       isMobile,
-      matchCase,
-      matchCount,
-      matches,
       needRefresh,
       offlineReady,
       pdfExportUnavailableReason,
       pwaBannerStatus,
-      query,
       renderedHtml,
-      replaceText,
       showBanner,
       showPwaBanner,
-      showReplace,
       sourceMap,
       stats,
       statusText,

--- a/packages/app/src/features/markdown/types/index.ts
+++ b/packages/app/src/features/markdown/types/index.ts
@@ -4,6 +4,8 @@ export type {
   EditorPaneAdapter,
   EditorScrollPayload,
   EditorWorkspaceController,
+  EditorWorkspaceFindAction,
+  EditorWorkspaceFindState,
   EditorWorkspaceState,
   PreviewPaneAdapter,
   ThemeChangeRequest,

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -64,16 +64,8 @@ export interface EditorWorkspaceController {
     pdf(): Promise<void>
   }
   find: {
-    close(): void
-    next(): void
-    open(): void
-    openReplace(): void
-    previous(): void
-    replaceAll(): Promise<void>
-    replaceCurrent(): Promise<void>
-    setMatchCase(value: boolean): void
-    setQuery(value: string): void
-    setReplaceText(value: string): void
+    dispatch(action: EditorWorkspaceFindAction): Promise<void>
+    state: ComputedRef<EditorWorkspaceFindState>
   }
   preview: {
     jumpToOffset(offset: number): Promise<void>
@@ -96,6 +88,29 @@ export interface EditorWorkspaceController {
   }
 }
 
+export type EditorWorkspaceFindAction =
+  | { type: 'close' }
+  | { type: 'next' }
+  | { type: 'open-replace' }
+  | { type: 'open' }
+  | { type: 'previous' }
+  | { type: 'replace-all' }
+  | { type: 'replace-current' }
+  | { type: 'set-match-case'; value: boolean }
+  | { type: 'set-query'; value: string }
+  | { type: 'set-replace-text'; value: string }
+
+export interface EditorWorkspaceFindState {
+  activeMatchIndex: number
+  isOpen: boolean
+  matchCase: boolean
+  matchCount: number
+  matches: FindMatch[]
+  query: string
+  replaceText: string
+  showReplace: boolean
+}
+
 /**
  * Controller-facing state shape consumed by the workspace view.
  *
@@ -104,7 +119,6 @@ export interface EditorWorkspaceController {
  * rather than the primary orchestration owner.
  */
 export interface EditorWorkspaceState {
-  activeMatchIndex: Readonly<Ref<number>>
   availableModes: Readonly<Ref<ViewMode[]>>
   bannerStatus: Readonly<Ref<'up-to-date' | 'update-available'>>
   bodyClasses: ComputedRef<Record<string, boolean>>
@@ -119,21 +133,14 @@ export interface EditorWorkspaceState {
   isDesktop: Readonly<Ref<boolean>>
   isDirty: Readonly<Ref<boolean>>
   isExamplesModalOpen: ShallowRef<boolean>
-  isFindReplaceOpen: Readonly<Ref<boolean>>
   isMobile: ShallowRef<boolean>
-  matchCase: Readonly<Ref<boolean>>
-  matchCount: Readonly<Ref<number>>
-  matches: Readonly<Ref<FindMatch[]>>
   needRefresh: Readonly<Ref<boolean>>
   offlineReady: Readonly<Ref<boolean>>
   pdfExportUnavailableReason: Readonly<Ref<string>>
   pwaBannerStatus: Readonly<Ref<'offline-ready' | 'update-available'>>
-  query: Readonly<Ref<string>>
   renderedHtml: Readonly<Ref<string>>
-  replaceText: Readonly<Ref<string>>
   showBanner: Readonly<Ref<boolean>>
   showPwaBanner: Readonly<Ref<boolean>>
-  showReplace: Readonly<Ref<boolean>>
   sourceMap: Readonly<Ref<MarkdownSourceMapEntry[]>>
   stats: Readonly<Ref<EditorStats>>
   statusText: Readonly<Ref<string>>

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -14,7 +14,6 @@ import { useEditorWorkspaceController } from '@/features/markdown/composables/us
 
 const workspace = useEditorWorkspaceController()
 const {
-  activeMatchIndex,
   availableModes,
   bannerStatus,
   bodyClasses,
@@ -27,19 +26,12 @@ const {
   isCopied,
   isDirty,
   isExamplesModalOpen,
-  isFindReplaceOpen,
   isMobile,
-  matchCase,
-  matchCount,
-  matches,
   pdfExportUnavailableReason,
   pwaBannerStatus,
-  query,
   renderedHtml,
-  replaceText,
   showBanner,
   showPwaBanner,
-  showReplace,
   sourceMap,
   stats,
   statusText,
@@ -161,30 +153,15 @@ function handleStartNewDocument(): void {
     </Transition>
 
     <main class="main-content">
+      <!-- workspace.find.state is a ComputedRef, so we pass its current snapshot via .value -->
       <EditorPane
         ref="editorPane"
-        :active-match-index="activeMatchIndex"
         :content="content"
-        :find-open="isFindReplaceOpen"
+        :find-state="workspace.find.state.value"
         :line-count="stats.lines"
-        :match-case="matchCase"
-        :match-count="matchCount"
-        :matches="matches"
-        :query="query"
-        :replace-text="replaceText"
-        :show-replace="showReplace"
-        @find:close="workspace.find.close"
-        @find:next="workspace.find.next"
-        @find:previous="workspace.find.previous"
-        @find:replace-all="workspace.find.replaceAll"
-        @find:replace-current="workspace.find.replaceCurrent"
-        @request-find="workspace.find.open"
-        @request-replace="workspace.find.openReplace"
+        @find-action="workspace.find.dispatch"
         @scroll="handleEditorScroll"
         @update:content="workspace.editor.updateContent"
-        @update:match-case="workspace.find.setMatchCase"
-        @update:query="workspace.find.setQuery"
-        @update:replace-text="workspace.find.setReplaceText"
       />
       <PreviewPane
         ref="previewPane"


### PR DESCRIPTION
## Summary

Moves find/replace orchestration behind the `useEditorWorkspaceController()` boundary, eliminating scattered view-level coordination between composables and component refs. The controller now exposes a unified `findState` computed property and a `dispatch()` action pattern for all find/replace workflows.

RFC: #46 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

N/A - internal refactoring with no UI changes

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified find/replace keyboard shortcuts, navigation, and replace flows work as expected

## Related Issue

Closes #49

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
