### PR TITLE
refactor(markdown): move document lifecycle into workspace controller

### DIFF
--- a/.changeset/document-lifecycle-controller.md
+++ b/.changeset/document-lifecycle-controller.md
@@ -1,0 +1,13 @@
+---
+"markdown-studio": patch
+"@markdown-studio/desktop": patch
+---
+
+Move document lifecycle workflows into workspace controller
+
+- Add `loadExampleDocument()` action to document session with proper state clearing, ensuring status bar correctly shows example title instead of stale file information
+- Add stable `id` field to Example type for reliable example selection
+- Move document lifecycle orchestration (open, save, startNew, restoreDraft, loadExample) into `useEditorWorkspaceController` with consistent focus management after every action
+- Change example selection from title-based to ID-based lookup for stability
+- Add warning for unknown example IDs without side effects
+- Ensure examples modal closes only after successful load

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@
 - Use the appropriate issue or PR template when creating a new issue or PR located in the `.github` directory.
 - If the template doesn't fit, update it to match the new use case.
 
+## Changesets Validation
+
+- `markdown-studio` package is always affected when `@markdown-studio/app`, `@markdown-studio/web` have changes.
+- Run `pnpm changeset:validate-scopes` after you perform changeset actions.
+
 ## Project Snapshot
 
 Markdown Studio is a Vue 3 + Electron Markdown editor with live preview, Mermaid diagram support, and a split web/desktop experience. The repo is intentionally lightweight and still evolving, so changes that improve long-term clarity, maintainability, and UI quality are welcome.

--- a/packages/app/src/features/markdown/components/ExampleCard.vue
+++ b/packages/app/src/features/markdown/components/ExampleCard.vue
@@ -8,11 +8,11 @@ interface Props {
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
-  select: [example: Example]
+  select: [exampleId: Example['id']]
 }>()
 
 function handleClick(): void {
-  emit('select', props.example)
+  emit('select', props.example.id)
 }
 
 function handleKeyDown(event: KeyboardEvent): void {

--- a/packages/app/src/features/markdown/components/ExamplesModal.vue
+++ b/packages/app/src/features/markdown/components/ExamplesModal.vue
@@ -14,16 +14,15 @@ const props = defineProps<Props>()
 
 const emit = defineEmits<{
   close: []
-  select: [example: Example]
+  select: [exampleId: Example['id']]
 }>()
 
 function handleClose(): void {
   emit('close')
 }
 
-function handleSelect(example: Example): void {
-  emit('select', example)
-  emit('close')
+function handleSelect(exampleId: Example['id']): void {
+  emit('select', exampleId)
 }
 </script>
 
@@ -34,7 +33,7 @@ function handleSelect(example: Example): void {
     </template>
     <ExampleCard
       v-for="example in EXAMPLES"
-      :key="example.title"
+      :key="example.id"
       :example="example"
       @select="handleSelect"
     />

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
@@ -115,6 +115,30 @@ describe('useDocumentSession', () => {
     expect(session.isDirty.value).toBe(false)
   })
 
+  it('clears previous file and edited state when loading an example', async () => {
+    const { content, session } = createSession()
+
+    await session.openDocument()
+    content.value = '# Edited loaded file'
+    await nextTick()
+
+    expect(session.currentPath.value).toBe('/tmp/loaded.md')
+    expect(session.isDirty.value).toBe(true)
+    expect(session.statusText.value).toContain('Edited')
+
+    await session.loadExampleDocument({
+      content: '# Example content',
+      title: 'Flowchart diagram',
+    })
+    await nextTick()
+
+    expect(content.value).toBe('# Example content')
+    expect(session.currentPath.value).toBe(null)
+    expect(session.displayName.value).toBe('Untitled.md')
+    expect(session.isDirty.value).toBe(false)
+    expect(session.statusText.value).toBe('Loaded example: Flowchart diagram')
+  })
+
   it('handles app command routing', async () => {
     const { session } = createSession()
 

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -123,6 +123,8 @@ describe('useEditorWorkspaceController', () => {
     const { workspace, wrapper } = await mountWorkspace()
     const editor = createEditorAdapter()
     workspace.attach.editor(editor)
+    await flushPromises()
+    vi.mocked(editor.focus).mockClear()
 
     workspace.editor.updateContent('cat dog cat')
     await workspace.find.dispatch({ type: 'set-query', value: 'cat' })
@@ -218,19 +220,36 @@ describe('useEditorWorkspaceController', () => {
     wrapper.unmount()
   })
 
-  it('loads an example and restores editor focus after the update flushes', async () => {
+  it('loads an example by id through the document api and restores editor focus', async () => {
     const { workspace, wrapper } = await mountWorkspace()
     const editor = createEditorAdapter()
     workspace.attach.editor(editor)
+    await flushPromises()
+    vi.mocked(editor.focus).mockClear()
 
-    await workspace.editor.loadExample({
-      content: '# Example content',
-      desc: 'Example description',
-      title: 'Example title',
-    })
+    await workspace.document.loadExample('flowchart-diagram')
 
-    expect(workspace.state.content.value).toBe('# Example content')
+    expect(workspace.state.content.value).toContain('# Git Feature Branch Workflow')
+    expect(workspace.state.statusText.value).toContain('Loaded example: Flowchart diagram')
     expect(editor.focus).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('warns and keeps the editor unchanged when an unknown example id is requested', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    const warningSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    workspace.attach.editor(editor)
+    workspace.editor.updateContent('# Existing content')
+    await flushPromises()
+    vi.mocked(editor.focus).mockClear()
+
+    await workspace.document.loadExample('unknown-example-id')
+
+    expect(workspace.state.content.value).toBe('# Existing content')
+    expect(editor.focus).not.toHaveBeenCalled()
+    expect(warningSpy).toHaveBeenCalledWith('Unknown example id received: unknown-example-id')
 
     wrapper.unmount()
   })
@@ -264,6 +283,60 @@ describe('useEditorWorkspaceController', () => {
     expect(workspace.state.content.value).toBe('# Restored draft')
     expect(workspace.state.displayName.value).toBe('notes.md')
     expect(workspace.state.isDirty.value).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('restores editor focus after every document lifecycle action', async () => {
+    const open = vi.fn(async () => ({ content: '# Opened', path: 'opened.md' }))
+    const save = vi.fn(async () => ({ path: 'saved.md' }))
+
+    appWindow.desktop = {
+      commands: {
+        onAppCommand: vi.fn(() => () => undefined),
+      },
+      documents: {
+        open,
+        save,
+        saveAs: async () => null,
+      },
+      editing: {
+        insertText: async () => undefined,
+      },
+      exports: {
+        exportHtml: async () => null,
+        exportPdf: async () => null,
+      },
+      isDesktop: true,
+      shell: {
+        openExternal: async () => undefined,
+      },
+    }
+
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+    await flushPromises()
+    vi.mocked(editor.focus).mockClear()
+
+    await workspace.document.open()
+    await workspace.document.save()
+    await workspace.document.startNew()
+
+    window.localStorage.setItem(
+      'markdown-studio:web-draft',
+      JSON.stringify({
+        content: '# Restored from storage',
+        label: 'draft.md',
+      }),
+    )
+
+    await workspace.document.restoreDraft()
+    await workspace.document.loadExample('flowchart-diagram')
+
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(editor.focus).toHaveBeenCalledTimes(5)
 
     wrapper.unmount()
   })

--- a/packages/app/src/features/markdown/composables/examples.ts
+++ b/packages/app/src/features/markdown/composables/examples.ts
@@ -32,6 +32,7 @@ flowchart TD
 > A branch is a hypothesis. Merge it when it's proven.
 `,
     desc: 'A git feature branch workflow rendered as a Mermaid flowchart.',
+    id: 'flowchart-diagram',
     title: 'Flowchart diagram',
   },
   {
@@ -69,6 +70,7 @@ sequenceDiagram
 Never store tokens in \`localStorage\` — use **HttpOnly cookies** for refresh tokens.
 `,
     desc: 'HTTP authentication flow with JWT tokens.',
+    id: 'sequence-diagram',
     title: 'Sequence diagram',
   },
   {
@@ -119,6 +121,7 @@ erDiagram
 Posts and comments share the same \`author_id\` FK pointing to \`USER.id\`.
 `,
     desc: 'A blog platform database schema as an ER diagram.',
+    id: 'entity-relationship-diagram',
     title: 'Entity relationship diagram',
   },
   {
@@ -151,6 +154,7 @@ gantt
 > All dates subject to review after beta feedback.
 `,
     desc: 'A product launch project timeline.',
+    id: 'gantt-chart',
     title: 'Gantt chart',
   },
   {
@@ -215,6 +219,7 @@ console.log(greet("world")); // Hello, world!
 *Happy writing.*
 `,
     desc: 'A document exercising all markdown features — headings, code, tables, quotes, and a diagram.',
+    id: 'full-kitchen-sink',
     title: 'Full kitchen-sink',
   },
 ]

--- a/packages/app/src/features/markdown/composables/useDocumentSession.ts
+++ b/packages/app/src/features/markdown/composables/useDocumentSession.ts
@@ -25,6 +25,7 @@ interface UseDocumentSessionReturn {
   handleAppCommand: (command: AppCommand) => Promise<void>
   isDesktop: ComputedRef<boolean>
   isDirty: ComputedRef<boolean>
+  loadExampleDocument: (input: { content: string; title: string }) => Promise<void>
   openDocument: () => Promise<void>
   restoreDraft: (input: { content: string; label: string }) => Promise<void>
   saveDocument: () => Promise<void>
@@ -89,6 +90,16 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
     draftLabel.value = input.label || 'Untitled.md'
     savedContent.value = ''
     lastAction.value = 'Restored local draft'
+    syncDocumentTitle()
+  }
+
+  async function loadExampleDocument(input: { content: string; title: string }): Promise<void> {
+    documents.clearCurrentDocumentReference()
+    options.replaceContent(input.content)
+    currentPath.value = null
+    draftLabel.value = null
+    savedContent.value = input.content
+    lastAction.value = `Loaded example: ${input.title}`
     syncDocumentTitle()
   }
 
@@ -161,6 +172,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
     handleAppCommand,
     isDesktop,
     isDirty,
+    loadExampleDocument,
     openDocument,
     restoreDraft,
     saveDocument,

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -7,7 +7,7 @@ import { usePwa } from '@/composables/usePwa'
 import { useThemeTransition } from '@/composables/useThemeTransition'
 import { useUpdateChecker } from '@/composables/useUpdateChecker'
 
-import type { ViewMode } from '../types'
+import type { Example, ViewMode } from '../types'
 import type {
   EditorPaneAdapter,
   EditorScrollPayload,
@@ -17,6 +17,7 @@ import type {
   ThemeChangeRequest,
 } from '../types/workspace'
 
+import { EXAMPLES } from './examples'
 import { useDocumentExport } from './useDocumentExport'
 import { useDocumentSession } from './useDocumentSession'
 import { useFindReplace } from './useFindReplace'
@@ -43,7 +44,6 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     content,
     copyContent,
     isCopied,
-    loadExample,
     renderedHtml,
     renderMermaidDiagrams,
     setTheme,
@@ -63,6 +63,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     handleAppCommand,
     isDesktop,
     isDirty,
+    loadExampleDocument,
     openDocument,
     restoreDraft,
     saveDocument,
@@ -319,11 +320,36 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     editorAdapter?.focus()
   }
 
+  async function focusEditorAfterDocumentAction(): Promise<void> {
+    await nextTick()
+    editorPane.value?.focus()
+  }
+
+  async function performDocumentAction(action: () => Promise<void>): Promise<void> {
+    await action()
+    await focusEditorAfterDocumentAction()
+  }
+
+  async function openWorkspaceDocument(): Promise<void> {
+    await performDocumentAction(openDocument)
+  }
+
+  async function saveWorkspaceDocument(): Promise<void> {
+    await performDocumentAction(saveDocument)
+  }
+
   async function startNew(): Promise<void> {
-    await startNewDocument()
-    if (!content.value) {
-      clearDraft()
-    }
+    await performDocumentAction(async () => {
+      await startNewDocument()
+
+      if (!content.value) {
+        clearDraft()
+      }
+    })
+  }
+
+  async function restoreWorkspaceDraft(): Promise<void> {
+    await performDocumentAction(restoreStoredDraft)
   }
 
   async function setWorkspaceTheme(request: ThemeChangeRequest): Promise<void> {
@@ -334,10 +360,20 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     })
   }
 
-  async function loadWorkspaceExample(example: Parameters<typeof loadExample>[0]): Promise<void> {
-    loadExample(example)
-    await nextTick()
-    editorPane.value?.focus()
+  async function loadWorkspaceExample(exampleId: Example['id']): Promise<void> {
+    const selectedExample = EXAMPLES.find((example) => example.id === exampleId)
+    if (!selectedExample) {
+      console.warn(`Unknown example id received: ${exampleId}`)
+      return
+    }
+
+    await performDocumentAction(async () => {
+      await loadExampleDocument({
+        content: selectedExample.content.trim(),
+        title: selectedExample.title,
+      })
+      closeExamples()
+    })
   }
 
   async function jumpToOffset(offset: number): Promise<void> {
@@ -359,7 +395,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       window.addEventListener('keydown', handleGlobalKeydown)
       startUpdateChecks()
       syncViewport(window.innerWidth)
-      await restoreStoredDraft()
+      await restoreWorkspaceDraft()
 
       const onAppCommand = desktop.value?.commands?.onAppCommand
       if (onAppCommand) {
@@ -477,23 +513,23 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       async handleAppCommand(command: AppCommand): Promise<void> {
         await handleDesktopCommand(command)
       },
+      async loadExample(exampleId: Example['id']): Promise<void> {
+        await loadWorkspaceExample(exampleId)
+      },
       async open(): Promise<void> {
-        await openDocument()
+        await openWorkspaceDocument()
       },
       async restoreDraft(): Promise<void> {
-        await restoreStoredDraft()
+        await restoreWorkspaceDraft()
       },
       async save(): Promise<void> {
-        await saveDocument()
+        await saveWorkspaceDocument()
       },
       async startNew(): Promise<void> {
         await startNew()
       },
     },
     editor: {
-      async loadExample(example) {
-        await loadWorkspaceExample(example)
-      },
       async setTheme(request: ThemeChangeRequest) {
         await setWorkspaceTheme(request)
       },

--- a/packages/app/src/features/markdown/types/common.ts
+++ b/packages/app/src/features/markdown/types/common.ts
@@ -8,6 +8,7 @@ export interface EditorStats {
 export interface Example {
   content: string
   desc: string
+  id: string
   title: string
 }
 

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -43,13 +43,13 @@ export interface EditorWorkspaceController {
   }
   document: {
     handleAppCommand(command: AppCommand): Promise<void>
+    loadExample(exampleId: Example['id']): Promise<void>
     open(): Promise<void>
     restoreDraft(): Promise<void>
     save(): Promise<void>
     startNew(): Promise<void>
   }
   editor: {
-    loadExample(example: Example): Promise<void>
     setTheme(request: ThemeChangeRequest): Promise<void>
     setViewMode(mode: ViewMode): void
     syncPreviewToEditorPosition(payload?: EditorScrollPayload | null): void

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -185,7 +185,7 @@ function handleStartNewDocument(): void {
     <ExamplesModal
       :is-open="isExamplesModalOpen"
       @close="workspace.examples.close"
-      @select="workspace.editor.loadExample"
+      @select="workspace.document.loadExample"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Moves document lifecycle orchestration (open, save, startNew, restoreDraft, loadExample) into `useEditorWorkspaceController` with consistent focus management. Adds `loadExampleDocument()` action to document session with proper state clearing, ensuring the status bar correctly shows example title instead of stale file information. Changes example selection from title-based to ID-based lookup for stability.

RFC: #46 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit` - Updated tests for `useDocumentSession` and `useEditorWorkspaceController`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified example loading clears stale file state and status bar shows correct example title. Confirmed focus management works consistently across all lifecycle actions.

## Related Issue

Closes #51

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
