### PR TITLE
feat(desktop): persist and restore last opened document

### DIFF
--- a/.changeset/thick-needles-marry.md
+++ b/.changeset/thick-needles-marry.md
@@ -1,0 +1,10 @@
+---
+'@markdown-studio/desktop': minor
+---
+
+Persist and restore the last opened document across desktop app restarts
+
+- Add two new IPC channels (`documents:restoreLastOpened`, `documents:clearLastOpened`)
+- Persist last opened file path to `document-state.json` in Electron's `userData` directory
+- Restore the previously opened file on desktop startup
+- Skip web draft fallback when running in desktop mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,18 @@
 ## Changesets Validation
 
 - `markdown-studio` package is always affected when `@markdown-studio/app`, `@markdown-studio/web` have changes.
+- Use the following format for generated changesets:
+
+  ```
+  Summary sentence describing the change
+
+  - Action verb describing one logical change
+  - Action verb describing another logical change
+  - Action verb describing yet another logical change
+  ```
+
+  Start with a summary line (no bullet), then a blank line, then unordered list items each beginning with a present-tense verb.
+
 - Run `pnpm changeset:validate-scopes` after you perform changeset actions.
 
 ## Project Snapshot

--- a/apps/desktop/electron/ipc/documents.ts
+++ b/apps/desktop/electron/ipc/documents.ts
@@ -1,7 +1,9 @@
 import type { DesktopDocumentHandle } from '@markdown-studio/desktop-contract/types'
 
 import {
+  DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL,
   DOCUMENTS_OPEN_CHANNEL,
+  DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL,
   DOCUMENTS_SAVE_AS_CHANNEL,
   DOCUMENTS_SAVE_CHANNEL,
   EDITING_INSERT_TEXT_CHANNEL,
@@ -17,8 +19,9 @@ import {
   getDefaultExportPath,
   getDefaultMarkdownPath,
 } from '@markdown-studio/desktop-contract/validation'
-import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { readFile, writeFile } from 'node:fs/promises'
+import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 
 const HTML_FILTERS = [
   { extensions: ['html'], name: 'HTML Files' },
@@ -32,6 +35,11 @@ const PDF_FILTERS = [
   { extensions: ['pdf'], name: 'PDF Files' },
   { extensions: ['*'], name: 'All Files' },
 ]
+const DOCUMENT_STATE_FILE = 'document-state.json'
+
+interface DocumentState {
+  lastOpenedPath?: string
+}
 
 export async function exportHtml(
   mainWindow: BrowserWindow,
@@ -110,16 +118,21 @@ export async function openDocument(
     return null
   }
 
+  let content: string
   try {
-    const content = await readFile(selectedPath, 'utf8')
-    return { content, path: selectedPath }
+    content = await readFile(selectedPath, 'utf8')
   } catch {
     throw new Error(`Failed to read file: ${selectedPath}`)
   }
+
+  await rememberLastOpenedPathSafe(selectedPath)
+  return { content, path: selectedPath }
 }
 
 export function registerDesktopIpc(mainWindow: BrowserWindow): void {
+  ipcMain.removeHandler(DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL)
   ipcMain.removeHandler(DOCUMENTS_OPEN_CHANNEL)
+  ipcMain.removeHandler(DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL)
   ipcMain.removeHandler(DOCUMENTS_SAVE_CHANNEL)
   ipcMain.removeHandler(DOCUMENTS_SAVE_AS_CHANNEL)
   ipcMain.removeHandler(EDITING_INSERT_TEXT_CHANNEL)
@@ -127,7 +140,9 @@ export function registerDesktopIpc(mainWindow: BrowserWindow): void {
   ipcMain.removeHandler(EXPORTS_PDF_CHANNEL)
   ipcMain.removeHandler(SHELL_OPEN_EXTERNAL_CHANNEL)
 
+  ipcMain.handle(DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL, async () => clearLastOpenedPath())
   ipcMain.handle(DOCUMENTS_OPEN_CHANNEL, async () => openDocument(mainWindow))
+  ipcMain.handle(DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL, async () => restoreLastOpenedDocument())
   ipcMain.handle(DOCUMENTS_SAVE_CHANNEL, async (_, payload) => saveDocument(mainWindow, payload))
   ipcMain.handle(DOCUMENTS_SAVE_AS_CHANNEL, async (_, payload) =>
     saveDocumentAs(mainWindow, payload),
@@ -142,6 +157,21 @@ export function registerDesktopIpc(mainWindow: BrowserWindow): void {
   )
 }
 
+export async function restoreLastOpenedDocument(): Promise<DesktopDocumentHandle | null> {
+  const state = await readDocumentState()
+  if (!state.lastOpenedPath) {
+    return null
+  }
+
+  try {
+    const content = await readFile(state.lastOpenedPath, 'utf8')
+    return { content, path: state.lastOpenedPath }
+  } catch {
+    await clearLastOpenedPath()
+    return null
+  }
+}
+
 export async function saveDocument(
   mainWindow: BrowserWindow,
   payload: unknown,
@@ -154,10 +184,12 @@ export async function saveDocument(
 
   try {
     await writeFile(input.path, input.content, 'utf8')
-    return { path: input.path }
   } catch {
     throw new Error(`Failed to save file: ${input.path}`)
   }
+
+  await rememberLastOpenedPathSafe(input.path)
+  return { path: input.path }
 }
 
 export async function saveDocumentAs(
@@ -177,9 +209,60 @@ export async function saveDocumentAs(
 
   try {
     await writeFile(result.filePath, input.content, 'utf8')
-    return { path: result.filePath }
   } catch {
     throw new Error(`Failed to save file: ${result.filePath}`)
+  }
+
+  await rememberLastOpenedPathSafe(result.filePath)
+  return { path: result.filePath }
+}
+
+async function clearLastOpenedPath(): Promise<void> {
+  try {
+    await unlink(getDocumentStatePath())
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      console.warn('Failed to clear last opened document state:', error)
+    }
+  }
+}
+
+function getDocumentStatePath(): string {
+  return join(app.getPath('userData'), DOCUMENT_STATE_FILE)
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+async function readDocumentState(): Promise<DocumentState> {
+  try {
+    const raw = await readFile(getDocumentStatePath(), 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+
+    if (typeof parsed !== 'object' || parsed === null || !('lastOpenedPath' in parsed)) {
+      return {}
+    }
+
+    return typeof parsed.lastOpenedPath === 'string'
+      ? { lastOpenedPath: parsed.lastOpenedPath }
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+async function rememberLastOpenedPath(filePath: string): Promise<void> {
+  const statePath = getDocumentStatePath()
+  await mkdir(dirname(statePath), { recursive: true })
+  await writeFile(statePath, JSON.stringify({ lastOpenedPath: filePath }), 'utf8')
+}
+
+async function rememberLastOpenedPathSafe(filePath: string): Promise<void> {
+  try {
+    await rememberLastOpenedPath(filePath)
+  } catch (error) {
+    console.warn('Failed to remember last opened document:', error)
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -42,6 +42,9 @@ async function createMainWindow(): Promise<BrowserWindow> {
     void openExternal(url)
   })
 
+  registerDesktopIpc(window)
+  Menu.setApplicationMenu(buildAppMenu(window))
+
   if (!app.isPackaged && process.env.ELECTRON_RENDERER_URL) {
     await window.loadURL(process.env.ELECTRON_RENDERER_URL)
   } else {
@@ -51,9 +54,6 @@ async function createMainWindow(): Promise<BrowserWindow> {
   if (!app.isPackaged) {
     window.webContents.openDevTools({ mode: 'detach' })
   }
-
-  registerDesktopIpc(window)
-  Menu.setApplicationMenu(buildAppMenu(window))
 
   return window
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -2,7 +2,9 @@ import type { DesktopApi } from '@markdown-studio/desktop-contract/types'
 
 import {
   APP_COMMAND_CHANNEL,
+  DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL,
   DOCUMENTS_OPEN_CHANNEL,
+  DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL,
   DOCUMENTS_SAVE_AS_CHANNEL,
   DOCUMENTS_SAVE_CHANNEL,
   EDITING_INSERT_TEXT_CHANNEL,
@@ -31,7 +33,9 @@ function createDesktopApi(): DesktopApi {
       },
     },
     documents: {
+      clearLastOpened: () => ipcRenderer.invoke(DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL),
       open: () => ipcRenderer.invoke(DOCUMENTS_OPEN_CHANNEL),
+      restoreLastOpened: () => ipcRenderer.invoke(DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL),
       save: (input) => ipcRenderer.invoke(DOCUMENTS_SAVE_CHANNEL, input),
       saveAs: (input) => ipcRenderer.invoke(DOCUMENTS_SAVE_AS_CHANNEL, input),
     },

--- a/packages/app/src/composables/useDesktop.ts
+++ b/packages/app/src/composables/useDesktop.ts
@@ -9,7 +9,9 @@ const fallbackDesktopApi: DesktopApi = {
     onAppCommand: () => () => undefined,
   },
   documents: {
+    clearLastOpened: async () => undefined,
     open: async () => null,
+    restoreLastOpened: async () => null,
     save: async () => null,
     saveAs: async () => null,
   },

--- a/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
@@ -157,7 +157,9 @@ describe('EditorPane', () => {
         onAppCommand: () => () => undefined,
       },
       documents: {
+        clearLastOpened: vi.fn(async () => undefined),
         open: async () => null,
+        restoreLastOpened: async () => null,
         save: async () => null,
         saveAs: async () => null,
       },

--- a/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
@@ -91,7 +91,9 @@ describe('PreviewPane', () => {
         onAppCommand: () => () => undefined,
       },
       documents: {
+        clearLastOpened: vi.fn(async () => undefined),
         open: async () => null,
+        restoreLastOpened: async () => null,
         save: async () => null,
         saveAs: async () => null,
       },

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentActions.spec.ts
@@ -9,7 +9,9 @@ const desktopMock = {
     onAppCommand: vi.fn(() => () => undefined),
   },
   documents: {
+    clearLastOpened: vi.fn(async () => undefined),
     open: vi.fn(async () => ({ content: '# Loaded', path: '/tmp/loaded.md' })),
+    restoreLastOpened: vi.fn(async () => null),
     save: vi.fn(async () => ({ path: '/tmp/saved.md' })),
     saveAs: vi.fn(async () => ({ path: '/tmp/saved-as.md' })),
   },
@@ -87,16 +89,20 @@ describe('useDocumentActions', () => {
     const actions = useDocumentActions()
 
     await actions.open()
+    await actions.restoreLastOpened()
     await actions.save({ content: '# Draft', path: null })
     await actions.saveAs({ content: '# Draft', suggestedPath: 'draft.md' })
+    await actions.clearCurrentDocumentReference()
 
     expect(actions.isDesktop.value).toBe(true)
     expect(desktopMock.documents.open).toHaveBeenCalled()
+    expect(desktopMock.documents.restoreLastOpened).toHaveBeenCalled()
     expect(desktopMock.documents.save).toHaveBeenCalledWith({ content: '# Draft', path: null })
     expect(desktopMock.documents.saveAs).toHaveBeenCalledWith({
       content: '# Draft',
       suggestedPath: 'draft.md',
     })
+    expect(desktopMock.documents.clearLastOpened).toHaveBeenCalled()
   })
 
   it('falls back to download when the browser save picker is unavailable', async () => {

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
@@ -179,7 +179,9 @@ describe('useDocumentExport', () => {
         onAppCommand: () => () => undefined,
       },
       documents: {
+        clearLastOpened: vi.fn(async () => undefined),
         open: async () => null,
+        restoreLastOpened: async () => null,
         save: async () => null,
         saveAs: async () => null,
       },

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentSession.spec.ts
@@ -11,7 +11,11 @@ const desktopMock = {
     onAppCommand: vi.fn(() => () => undefined),
   },
   documents: {
+    clearLastOpened: vi.fn(async () => undefined),
     open: vi.fn(async () => ({ content: '# Loaded', path: '/tmp/loaded.md' })),
+    restoreLastOpened: vi.fn<() => Promise<{ content: string; path: string } | null>>(
+      async () => null,
+    ),
     save: vi.fn(async ({ path }: { path: null | string }) => ({ path: path ?? '/tmp/saved.md' })),
     saveAs: vi.fn(async () => ({ path: '/tmp/saved-as.md' })),
   },
@@ -81,6 +85,23 @@ describe('useDocumentSession', () => {
     expect(session.canSaveDocuments.value).toBe(true)
   })
 
+  it('restores the last opened desktop document as clean saved work', async () => {
+    desktopMock.documents.restoreLastOpened.mockResolvedValueOnce({
+      content: '# Restored file',
+      path: '/tmp/restored.md',
+    })
+    const { content, session } = createSession()
+
+    await session.restoreLastOpenedDocument()
+    await nextTick()
+
+    expect(content.value).toBe('# Restored file')
+    expect(session.currentPath.value).toBe('/tmp/restored.md')
+    expect(session.displayName.value).toBe('restored.md')
+    expect(session.isDirty.value).toBe(false)
+    expect(session.statusText.value).toBe('Restored restored.md')
+  })
+
   it('restores a saved web draft as unsaved work', async () => {
     const { content, session } = createSession()
 
@@ -137,6 +158,7 @@ describe('useDocumentSession', () => {
     expect(session.displayName.value).toBe('Untitled.md')
     expect(session.isDirty.value).toBe(false)
     expect(session.statusText.value).toBe('Loaded example: Flowchart diagram')
+    expect(desktopMock.documents.clearLastOpened).toHaveBeenCalled()
   })
 
   it('handles app command routing', async () => {

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -287,6 +287,99 @@ describe('useEditorWorkspaceController', () => {
     wrapper.unmount()
   })
 
+  it('restores the last opened desktop document during startup', async () => {
+    const restoreLastOpened = vi.fn(async () => ({
+      content: '# Desktop restored',
+      path: '/tmp/desktop-restored.md',
+    }))
+
+    window.localStorage.setItem(
+      'markdown-studio:web-draft',
+      JSON.stringify({
+        content: '# Web draft should be ignored',
+        label: 'draft.md',
+      }),
+    )
+    appWindow.desktop = {
+      commands: {
+        onAppCommand: vi.fn(() => () => undefined),
+      },
+      documents: {
+        clearLastOpened: async () => undefined,
+        open: async () => null,
+        restoreLastOpened,
+        save: async () => null,
+        saveAs: async () => null,
+      },
+      editing: {
+        insertText: async () => undefined,
+      },
+      exports: {
+        exportHtml: async () => null,
+        exportPdf: async () => null,
+      },
+      isDesktop: true,
+      shell: {
+        openExternal: async () => undefined,
+      },
+    }
+
+    const { workspace, wrapper } = await mountWorkspace()
+    await flushPromises()
+
+    expect(restoreLastOpened).toHaveBeenCalledTimes(1)
+    expect(workspace.state.content.value).toBe('# Desktop restored')
+    expect(workspace.state.displayName.value).toBe('desktop-restored.md')
+    expect(workspace.state.isDirty.value).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('does not fall back to web draft storage during desktop startup', async () => {
+    const restoreLastOpened = vi.fn(async () => null)
+
+    window.localStorage.setItem(
+      'markdown-studio:web-draft',
+      JSON.stringify({
+        content: '# Web draft should be ignored',
+        label: 'draft.md',
+      }),
+    )
+    appWindow.desktop = {
+      commands: {
+        onAppCommand: vi.fn(() => () => undefined),
+      },
+      documents: {
+        clearLastOpened: async () => undefined,
+        open: async () => null,
+        restoreLastOpened,
+        save: async () => null,
+        saveAs: async () => null,
+      },
+      editing: {
+        insertText: async () => undefined,
+      },
+      exports: {
+        exportHtml: async () => null,
+        exportPdf: async () => null,
+      },
+      isDesktop: true,
+      shell: {
+        openExternal: async () => undefined,
+      },
+    }
+
+    const { workspace, wrapper } = await mountWorkspace()
+    await flushPromises()
+
+    expect(restoreLastOpened).toHaveBeenCalledTimes(1)
+    expect(workspace.state.content.value).not.toBe('# Web draft should be ignored')
+    expect(workspace.state.displayName.value).toBe('Untitled.md')
+    expect(workspace.state.isDirty.value).toBe(false)
+
+    wrapper.unmount()
+  })
+
   it('restores editor focus after every document lifecycle action', async () => {
     const open = vi.fn(async () => ({ content: '# Opened', path: 'opened.md' }))
     const save = vi.fn(async () => ({ path: 'saved.md' }))
@@ -296,7 +389,9 @@ describe('useEditorWorkspaceController', () => {
         onAppCommand: vi.fn(() => () => undefined),
       },
       documents: {
+        clearLastOpened: async () => undefined,
         open,
+        restoreLastOpened: async () => null,
         save,
         saveAs: async () => null,
       },
@@ -350,7 +445,9 @@ describe('useEditorWorkspaceController', () => {
         onAppCommand,
       },
       documents: {
+        clearLastOpened: vi.fn(async () => undefined),
         open: async () => null,
+        restoreLastOpened: async () => null,
         save: async () => null,
         saveAs: async () => null,
       },

--- a/packages/app/src/features/markdown/composables/useDocumentActions.ts
+++ b/packages/app/src/features/markdown/composables/useDocumentActions.ts
@@ -13,9 +13,10 @@ interface BrowserOpenResult {
 interface DocumentActions {
   canOpenDocuments: ComputedRef<boolean>
   canSaveDocuments: ComputedRef<boolean>
-  clearCurrentDocumentReference: () => void
+  clearCurrentDocumentReference: () => Promise<void>
   isDesktop: ComputedRef<boolean>
   open: () => Promise<DocumentHandle | null>
+  restoreLastOpened: () => Promise<DocumentHandle | null>
   save: (input: SaveDocumentInput) => Promise<{ path: string } | null>
   saveAs: (input: SaveDocumentAsInput) => Promise<{ path: string } | null>
 }
@@ -103,12 +104,21 @@ export function useDocumentActions(): DocumentActions {
     return { path: suggestedPath }
   }
 
+  async function restoreLastOpened(): Promise<DocumentHandle | null> {
+    if (!isDesktop.value) {
+      return null
+    }
+
+    return desktop.value.documents.restoreLastOpened()
+  }
+
   return {
     canOpenDocuments,
     canSaveDocuments,
     clearCurrentDocumentReference,
     isDesktop,
     open,
+    restoreLastOpened,
     save,
     saveAs,
   }
@@ -119,11 +129,18 @@ const browserSession: { handle: FileSystemFileHandle | null } = {
 }
 
 export function resetBrowserDocumentSessionForTests(): void {
-  clearCurrentDocumentReference()
+  browserSession.handle = null
 }
 
-function clearCurrentDocumentReference(): void {
+async function clearCurrentDocumentReference(): Promise<void> {
   browserSession.handle = null
+
+  if (typeof window === 'undefined') return
+
+  const desktop = (window as AppWindow).desktop
+  if (desktop?.isDesktop) {
+    await desktop.documents.clearLastOpened()
+  }
 }
 
 function downloadDocument(content: string, fileName: string): void {

--- a/packages/app/src/features/markdown/composables/useDocumentSession.ts
+++ b/packages/app/src/features/markdown/composables/useDocumentSession.ts
@@ -28,6 +28,7 @@ interface UseDocumentSessionReturn {
   loadExampleDocument: (input: { content: string; title: string }) => Promise<void>
   openDocument: () => Promise<void>
   restoreDraft: (input: { content: string; label: string }) => Promise<void>
+  restoreLastOpenedDocument: () => Promise<void>
   saveDocument: () => Promise<void>
   saveDocumentAs: () => Promise<void>
   startNewDocument: () => Promise<void>
@@ -93,8 +94,20 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
     syncDocumentTitle()
   }
 
+  async function restoreLastOpenedDocument(): Promise<void> {
+    const restored = await documents.restoreLastOpened()
+    if (!restored) return
+
+    options.replaceContent(restored.content)
+    currentPath.value = restored.path
+    draftLabel.value = null
+    savedContent.value = restored.content
+    lastAction.value = `Restored ${getFileName(restored.path)}`
+    syncDocumentTitle()
+  }
+
   async function loadExampleDocument(input: { content: string; title: string }): Promise<void> {
-    documents.clearCurrentDocumentReference()
+    await documents.clearCurrentDocumentReference()
     options.replaceContent(input.content)
     currentPath.value = null
     draftLabel.value = null
@@ -136,7 +149,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
   async function startNewDocument(): Promise<void> {
     if (!(await confirmDiscardChanges())) return
 
-    documents.clearCurrentDocumentReference()
+    await documents.clearCurrentDocumentReference()
     options.replaceContent('')
     currentPath.value = null
     draftLabel.value = null
@@ -175,6 +188,7 @@ export function useDocumentSession(options: UseDocumentSessionOptions): UseDocum
     loadExampleDocument,
     openDocument,
     restoreDraft,
+    restoreLastOpenedDocument,
     saveDocument,
     saveDocumentAs,
     startNewDocument,

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -66,6 +66,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     loadExampleDocument,
     openDocument,
     restoreDraft,
+    restoreLastOpenedDocument,
     saveDocument,
     startNewDocument,
     statusText,
@@ -349,7 +350,14 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   }
 
   async function restoreWorkspaceDraft(): Promise<void> {
-    await performDocumentAction(restoreStoredDraft)
+    await performDocumentAction(async () => {
+      if (isDesktop.value) {
+        await restoreLastOpenedDocument()
+        return
+      }
+
+      await restoreStoredDraft()
+    })
   }
 
   async function setWorkspaceTheme(request: ThemeChangeRequest): Promise<void> {

--- a/packages/app/src/utils/__tests__/platform.spec.ts
+++ b/packages/app/src/utils/__tests__/platform.spec.ts
@@ -9,7 +9,9 @@ const desktopBridgeMock = {
     onAppCommand: () => () => undefined,
   },
   documents: {
+    clearLastOpened: async () => undefined,
     open: async () => null,
+    restoreLastOpened: async () => null,
     save: async () => null,
     saveAs: async () => null,
   },

--- a/packages/desktop-contract/src/channels.ts
+++ b/packages/desktop-contract/src/channels.ts
@@ -1,5 +1,7 @@
 export const APP_COMMAND_CHANNEL = 'app:command'
+export const DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL = 'documents:clearLastOpened'
 export const DOCUMENTS_OPEN_CHANNEL = 'documents:open'
+export const DOCUMENTS_RESTORE_LAST_OPENED_CHANNEL = 'documents:restoreLastOpened'
 export const DOCUMENTS_SAVE_AS_CHANNEL = 'documents:saveAs'
 export const DOCUMENTS_SAVE_CHANNEL = 'documents:save'
 export const EDITING_INSERT_TEXT_CHANNEL = 'editing:insertText'

--- a/packages/desktop-contract/src/types.ts
+++ b/packages/desktop-contract/src/types.ts
@@ -27,7 +27,9 @@ export interface DesktopDocumentHandle {
 }
 
 export interface DesktopDocumentsApi {
+  clearLastOpened: () => Promise<void>
   open: () => Promise<DesktopDocumentHandle | null>
+  restoreLastOpened: () => Promise<DesktopDocumentHandle | null>
   save: (input: DesktopSaveInput) => Promise<{ path: string } | null>
   saveAs: (input: DesktopSaveAsInput) => Promise<{ path: string } | null>
 }


### PR DESCRIPTION
## Summary

Implements desktop support for restoring the last opened markdown file on app startup/reload, matching the PWA draft persistence behavior. The last opened file path is persisted to a JSON file under Electron's `userData` directory and restored on startup as a clean saved document.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

| Before | After |
| ------ | ----- |
| Desktop app starts on untitled document every time | Desktop app reopens the last markdown file automatically |

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes:
  - Verified last opened file persists after close/reopen of the Electron app
  - Verified restored file is treated as clean (not dirty) with correct path and display name
  - Verified missing/unreadable files fall back to untitled document
  - Verified New Document and example-loading clear the remembered path
  - Verified web draft persistence remains unchanged

## Related Issue

Closes #60

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
