### PR TITLE
refactor(markdown): extract draft persistence seam

### DIFF
--- a/.changeset/late-dragons-rest.md
+++ b/.changeset/late-dragons-rest.md
@@ -1,0 +1,9 @@
+---
+"@markdown-studio/desktop": patch
+"markdown-studio": patch
+---
+
+Extract shared draft persistence debounce logic into reusable composable
+
+- Introduce `useDebouncedDraftPersistence` with adapter interface to consolidate duplicated debounce, generation-tracking, and flag logic
+- Eliminate double JSON.stringify on the web write path by passing pre-serialized string to adapters

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 
 ## Issue and PR Templates
 
+- Before creating a PR, make sure to run `pnpm changeset:validate-scopes` to validate the changeset scopes. If there is no changeset file, create one. If the changeset file is not valid, update it to match the new use case.
 - Use the appropriate issue or PR template when creating a new issue or PR located in the `.github` directory.
 - If the template doesn't fit, update it to match the new use case.
 

--- a/packages/app/src/features/markdown/composables/__tests__/useWebDraftPersistence.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useWebDraftPersistence.spec.ts
@@ -114,7 +114,7 @@ describe('useWebDraftPersistence', () => {
 
     expect(window.localStorage.getItem('markdown-studio:web-draft')).not.toBeNull()
 
-    persistence.clearDraft()
+    await persistence.clearDraft()
 
     expect(window.localStorage.getItem('markdown-studio:web-draft')).toBeNull()
   })

--- a/packages/app/src/features/markdown/composables/useDebouncedDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useDebouncedDraftPersistence.ts
@@ -1,0 +1,167 @@
+import { readonly, shallowRef, watch } from 'vue'
+
+export interface DebouncedDraftPersistenceOptions<TPayload> {
+  /**
+   * Whether persistence is currently active.
+   * Web persistence is active when NOT on desktop; desktop persistence is
+   * active when ON desktop. The composable treats `false` as "do nothing."
+   */
+  active: () => boolean
+
+  adapter: DraftPersistenceAdapter<TPayload>
+
+  /** Build the payload from the current component state. */
+  buildPayload: () => TPayload
+
+  /** Debounce delay in milliseconds (default 250). */
+  delay?: number
+
+  /** Whether the document has unsaved changes. When false, the draft is cleared. */
+  isDirty: () => boolean
+
+  /** Called when `restoreStoredDraft` finds a stored draft. */
+  onRestore: (payload: TPayload) => Promise<void>
+
+  /** Reactive sources to watch. When any change, a debounced persist is scheduled. */
+  watchSources: () => unknown[]
+}
+
+export interface DebouncedDraftPersistenceReturn {
+  /** Cancel pending writes and remove the stored draft. */
+  clearDraft: () => Promise<void>
+  /** Whether the last persist attempt failed (e.g., quota exceeded). */
+  persistFailed: Readonly<ReturnType<typeof shallowRef<boolean>>>
+  /** Whether `restoreStoredDraft` has already been called. */
+  restored: Readonly<ReturnType<typeof shallowRef<boolean>>>
+  /**
+   * Read a stored draft and call `onRestore` if one exists.
+   * Returns `true` when a draft was restored.
+   */
+  restoreStoredDraft: () => Promise<boolean>
+}
+
+/**
+ * Storage adapter for a single draft backend (localStorage, desktop IPC, etc.).
+ *
+ * Each adapter is a thin module that knows *where* to store a draft but not
+ * *when* — the debounce and dirty-tracking live in the shared composable.
+ */
+export interface DraftPersistenceAdapter<TPayload> {
+  /** Remove the stored draft. */
+  clear(): Promise<void>
+  /** Maximum serialized payload size in bytes before the draft is skipped. */
+  readonly maxSizeBytes: number
+  /** Read a previously stored draft, or null if none exists. */
+  read(): Promise<null | TPayload>
+  /** Persist the payload. Called after the debounce delay. */
+  write(payload: TPayload): Promise<void>
+}
+
+/**
+ * Shared debounce-and-flag logic for draft persistence.
+ *
+ * Both the web (localStorage) and desktop (IPC) draft modules use this
+ * composable so that the debounce watcher, `restored` flag, and
+ * `persistFailed` flag live in one place.
+ */
+export function useDebouncedDraftPersistence<TPayload>(
+  options: DebouncedDraftPersistenceOptions<TPayload>,
+): DebouncedDraftPersistenceReturn {
+  const restored = shallowRef(false)
+  const persistFailed = shallowRef(false)
+  const delay = options.delay ?? 250
+  let writeTimeoutId: ReturnType<typeof setTimeout> | undefined
+  let writeGeneration = 0
+
+  async function persist(payload: TPayload, generation: number): Promise<void> {
+    try {
+      const serialized = JSON.stringify(payload)
+
+      if (serialized.length > options.adapter.maxSizeBytes) {
+        console.warn('Draft too large to persist')
+        persistFailed.value = true
+        return
+      }
+
+      await options.adapter.write(payload)
+
+      if (generation !== writeGeneration) {
+        return
+      }
+
+      persistFailed.value = false
+    } catch {
+      console.warn('Failed to persist draft')
+      persistFailed.value = true
+    }
+  }
+
+  async function restoreStoredDraft(): Promise<boolean> {
+    if (!options.active() || restored.value) {
+      return false
+    }
+
+    const stored = await options.adapter.read()
+    restored.value = true
+
+    if (!stored) {
+      return false
+    }
+
+    await options.onRestore(stored)
+    return true
+  }
+
+  async function clearDraft(): Promise<void> {
+    if (writeTimeoutId !== undefined) {
+      clearTimeout(writeTimeoutId)
+      writeTimeoutId = undefined
+    }
+
+    writeGeneration++
+
+    if (!options.active()) {
+      return
+    }
+
+    try {
+      await options.adapter.clear()
+      persistFailed.value = false
+    } catch {
+      console.warn('Failed to clear draft')
+      persistFailed.value = true
+    }
+  }
+
+  watch(
+    options.watchSources,
+    () => {
+      if (!options.active() || !restored.value) {
+        return
+      }
+
+      if (!options.isDirty()) {
+        void clearDraft()
+        return
+      }
+
+      if (writeTimeoutId !== undefined) {
+        clearTimeout(writeTimeoutId)
+      }
+
+      writeTimeoutId = setTimeout(() => {
+        const generation = ++writeGeneration
+        void persist(options.buildPayload(), generation)
+        writeTimeoutId = undefined
+      }, delay)
+    },
+    { immediate: true },
+  )
+
+  return {
+    clearDraft,
+    persistFailed: readonly(persistFailed),
+    restored: readonly(restored),
+    restoreStoredDraft,
+  }
+}

--- a/packages/app/src/features/markdown/composables/useDebouncedDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useDebouncedDraftPersistence.ts
@@ -53,8 +53,8 @@ export interface DraftPersistenceAdapter<TPayload> {
   readonly maxSizeBytes: number
   /** Read a previously stored draft, or null if none exists. */
   read(): Promise<null | TPayload>
-  /** Persist the payload. Called after the debounce delay. */
-  write(payload: TPayload): Promise<void>
+  /** Persist the payload. Receives the pre-serialized string to avoid double JSON.stringify. */
+  write(payload: TPayload, serialized: string): Promise<void>
 }
 
 /**
@@ -83,7 +83,7 @@ export function useDebouncedDraftPersistence<TPayload>(
         return
       }
 
-      await options.adapter.write(payload)
+      await options.adapter.write(payload, serialized)
 
       if (generation !== writeGeneration) {
         return

--- a/packages/app/src/features/markdown/composables/useDesktopDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useDesktopDraftPersistence.ts
@@ -40,8 +40,8 @@ export function useDesktopDraftPersistence(options: UseDesktopDraftPersistenceOp
       return stored?.activeDocument ?? null
     },
 
-    async write(payload) {
-      await desktop.value.documents.saveWorkspaceDraft({ activeDocument: payload })
+    async write(_payload, _serialized) {
+      await desktop.value.documents.saveWorkspaceDraft({ activeDocument: _payload })
     },
   }
 

--- a/packages/app/src/features/markdown/composables/useDesktopDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useDesktopDraftPersistence.ts
@@ -1,6 +1,10 @@
-import { type ComputedRef, readonly, shallowRef, watch } from 'vue'
+import type { ComputedRef } from 'vue'
 
 import { useDesktop } from '@/composables/useDesktop'
+
+import type { DraftPersistenceAdapter } from './useDebouncedDraftPersistence'
+
+import { useDebouncedDraftPersistence } from './useDebouncedDraftPersistence'
 
 interface DesktopDraftPayload {
   content: string
@@ -19,90 +23,40 @@ interface UseDesktopDraftPersistenceOptions {
   savedContent: { value: string } | ComputedRef<string>
 }
 
-interface UseDesktopDraftPersistenceReturn {
-  clearDraft: () => Promise<void>
-  persistFailed: Readonly<ReturnType<typeof shallowRef<boolean>>>
-  restored: Readonly<ReturnType<typeof shallowRef<boolean>>>
-  restoreStoredDraft: () => Promise<boolean>
-}
-
-const WRITE_DELAY_MS = 250
 const MAX_DRAFT_SIZE_BYTES = 5 * 1024 * 1024
 
-export function useDesktopDraftPersistence(
-  options: UseDesktopDraftPersistenceOptions,
-): UseDesktopDraftPersistenceReturn {
+export function useDesktopDraftPersistence(options: UseDesktopDraftPersistenceOptions) {
   const desktop = useDesktop()
-  const restored = shallowRef(false)
-  const persistFailed = shallowRef(false)
-  let writeTimeoutId: ReturnType<typeof setTimeout> | undefined
-  let writeGeneration = 0
 
-  async function persistDraft(payload: DesktopDraftPayload, generation: number): Promise<void> {
-    try {
-      const draft = {
-        activeDocument: payload,
-      }
-      const serialized = JSON.stringify(draft)
-
-      if (serialized.length > MAX_DRAFT_SIZE_BYTES) {
-        console.warn('Desktop draft too large to persist')
-        persistFailed.value = true
-        return
-      }
-
-      await desktop.value.documents.saveWorkspaceDraft(draft)
-
-      if (generation !== writeGeneration) {
-        return
-      }
-
-      persistFailed.value = false
-    } catch {
-      console.warn('Failed to persist desktop draft')
-      persistFailed.value = true
-    }
-  }
-
-  async function restoreStoredDraft(): Promise<boolean> {
-    if (!options.isDesktop.value || restored.value) {
-      return false
-    }
-
-    const storedDraft = await desktop.value.documents.restoreWorkspaceDraft()
-    restored.value = true
-
-    if (!storedDraft) {
-      return false
-    }
-
-    await options.restoreDraft(storedDraft.activeDocument)
-    return true
-  }
-
-  async function clearDraft(): Promise<void> {
-    if (writeTimeoutId !== undefined) {
-      clearTimeout(writeTimeoutId)
-      writeTimeoutId = undefined
-    }
-
-    writeGeneration++
-
-    if (!options.isDesktop.value) {
-      return
-    }
-
-    try {
+  const adapter: DraftPersistenceAdapter<DesktopDraftPayload> = {
+    async clear() {
       await desktop.value.documents.clearWorkspaceDraft()
-      persistFailed.value = false
-    } catch {
-      console.warn('Failed to clear desktop draft')
-      persistFailed.value = true
-    }
+    },
+
+    maxSizeBytes: MAX_DRAFT_SIZE_BYTES,
+
+    async read() {
+      const stored = await desktop.value.documents.restoreWorkspaceDraft()
+      return stored?.activeDocument ?? null
+    },
+
+    async write(payload) {
+      await desktop.value.documents.saveWorkspaceDraft({ activeDocument: payload })
+    },
   }
 
-  watch(
-    () =>
+  return useDebouncedDraftPersistence({
+    active: () => options.isDesktop.value,
+    adapter,
+    buildPayload: () => ({
+      content: options.content.value,
+      label: options.displayName.value,
+      path: options.currentPath.value,
+      savedContent: options.savedContent.value,
+    }),
+    isDirty: () => options.isDirty.value,
+    onRestore: options.restoreDraft,
+    watchSources: () =>
       [
         options.content.value,
         options.currentPath.value,
@@ -111,41 +65,5 @@ export function useDesktopDraftPersistence(
         options.isDirty.value,
         options.savedContent.value,
       ] as const,
-    ([content, currentPath, displayName, isDesktop, isDirty, savedContent]) => {
-      if (!isDesktop || !restored.value) {
-        return
-      }
-
-      if (!isDirty) {
-        void clearDraft()
-        return
-      }
-
-      if (writeTimeoutId !== undefined) {
-        clearTimeout(writeTimeoutId)
-      }
-
-      writeTimeoutId = setTimeout(() => {
-        const generation = ++writeGeneration
-        void persistDraft(
-          {
-            content,
-            label: displayName,
-            path: currentPath,
-            savedContent,
-          },
-          generation,
-        )
-        writeTimeoutId = undefined
-      }, WRITE_DELAY_MS)
-    },
-    { immediate: true },
-  )
-
-  return {
-    clearDraft,
-    persistFailed: readonly(persistFailed),
-    restored: readonly(restored),
-    restoreStoredDraft,
-  }
+  })
 }

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -356,7 +356,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       await startNewDocument()
 
       if (!content.value) {
-        clearDraft()
+        await clearDraft()
         await clearDesktopDraft()
       }
     })

--- a/packages/app/src/features/markdown/composables/useWebDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useWebDraftPersistence.ts
@@ -18,6 +18,7 @@ interface UseWebDraftPersistenceOptions {
 }
 
 const STORAGE_KEY = 'markdown-studio:web-draft'
+// 1MB limit to stay well under typical 5-10MB localStorage quotas
 const MAX_DRAFT_SIZE_BYTES = 1024 * 1024
 
 export function clearStoredWebDraft(): void {
@@ -63,8 +64,8 @@ export function useWebDraftPersistence(options: UseWebDraftPersistenceOptions) {
       return readStoredWebDraft()
     },
 
-    async write(payload) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    async write(_payload, serialized) {
+      localStorage.setItem(STORAGE_KEY, serialized)
     },
   }
 

--- a/packages/app/src/features/markdown/composables/useWebDraftPersistence.ts
+++ b/packages/app/src/features/markdown/composables/useWebDraftPersistence.ts
@@ -1,4 +1,8 @@
-import { type ComputedRef, readonly, shallowRef, watch } from 'vue'
+import type { ComputedRef } from 'vue'
+
+import type { DraftPersistenceAdapter } from './useDebouncedDraftPersistence'
+
+import { useDebouncedDraftPersistence } from './useDebouncedDraftPersistence'
 
 interface StoredDraftPayload {
   content: string
@@ -13,16 +17,8 @@ interface UseWebDraftPersistenceOptions {
   restoreDraft: (payload: StoredDraftPayload) => Promise<void>
 }
 
-interface UseWebDraftPersistenceReturn {
-  clearDraft: () => void
-  persistFailed: Readonly<ReturnType<typeof shallowRef<boolean>>>
-  restored: Readonly<ReturnType<typeof shallowRef<boolean>>>
-  restoreStoredDraft: () => Promise<void>
-}
-
 const STORAGE_KEY = 'markdown-studio:web-draft'
-const WRITE_DELAY_MS = 250
-const MAX_DRAFT_SIZE_BYTES = 1024 * 1024 // 1MB limit to stay well under typical 5-10MB localStorage quotas
+const MAX_DRAFT_SIZE_BYTES = 1024 * 1024
 
 export function clearStoredWebDraft(): void {
   if (typeof localStorage !== 'undefined') {
@@ -55,97 +51,38 @@ export function readStoredWebDraft(): null | StoredDraftPayload {
   }
 }
 
-export function useWebDraftPersistence(
-  options: UseWebDraftPersistenceOptions,
-): UseWebDraftPersistenceReturn {
-  const restored = shallowRef(false)
-  const persistFailed = shallowRef(false)
-  let writeTimeoutId: ReturnType<typeof setTimeout> | undefined
+export function useWebDraftPersistence(options: UseWebDraftPersistenceOptions) {
+  const adapter: DraftPersistenceAdapter<StoredDraftPayload> = {
+    async clear() {
+      clearStoredWebDraft()
+    },
 
-  function persistDraft(payload: StoredDraftPayload): void {
-    if (typeof localStorage === 'undefined') {
-      return
-    }
+    maxSizeBytes: MAX_DRAFT_SIZE_BYTES,
 
-    try {
-      const serialized = JSON.stringify(payload)
+    async read() {
+      return readStoredWebDraft()
+    },
 
-      if (serialized.length > MAX_DRAFT_SIZE_BYTES) {
-        console.warn('Draft too large to persist to localStorage')
-        persistFailed.value = true
-        return
-      }
-
-      localStorage.setItem(STORAGE_KEY, serialized)
-      persistFailed.value = false
-    } catch {
-      console.warn('Failed to persist draft to localStorage')
-      persistFailed.value = true
-    }
+    async write(payload) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    },
   }
 
-  async function restoreStoredDraft(): Promise<void> {
-    if (options.isDesktop.value || restored.value) {
-      return
-    }
-
-    const storedDraft = readStoredWebDraft()
-
-    if (!storedDraft) {
-      restored.value = true
-      return
-    }
-
-    await options.restoreDraft(storedDraft)
-    restored.value = true
-  }
-
-  function clearDraft(): void {
-    if (writeTimeoutId !== undefined) {
-      clearTimeout(writeTimeoutId)
-      writeTimeoutId = undefined
-    }
-
-    clearStoredWebDraft()
-  }
-
-  watch(
-    () =>
+  return useDebouncedDraftPersistence({
+    active: () => !options.isDesktop.value,
+    adapter,
+    buildPayload: () => ({
+      content: options.content.value,
+      label: options.displayName.value,
+    }),
+    isDirty: () => options.isDirty.value,
+    onRestore: options.restoreDraft,
+    watchSources: () =>
       [
         options.content.value,
         options.displayName.value,
         options.isDesktop.value,
         options.isDirty.value,
       ] as const,
-    ([content, displayName, isDesktop, isDirty]) => {
-      if (isDesktop || !restored.value) {
-        return
-      }
-
-      if (!isDirty) {
-        clearDraft()
-        return
-      }
-
-      if (writeTimeoutId !== undefined) {
-        clearTimeout(writeTimeoutId)
-      }
-
-      writeTimeoutId = setTimeout(() => {
-        persistDraft({
-          content,
-          label: displayName,
-        })
-        writeTimeoutId = undefined
-      }, WRITE_DELAY_MS)
-    },
-    { immediate: true },
-  )
-
-  return {
-    clearDraft,
-    persistFailed: readonly(persistFailed),
-    restored: readonly(restored),
-    restoreStoredDraft,
-  }
+  })
 }


### PR DESCRIPTION
## Summary

Extract the duplicated debounce, generation-tracking, and flag logic from `useWebDraftPersistence` and `useDesktopDraftPersistence` into a shared `useDebouncedDraftPersistence` composable. Both existing composables now delegate to it via a `DraftPersistenceAdapter` interface, eliminating ~200 lines of duplicated watch/persist/clear logic. A follow-up fix pass eliminates double `JSON.stringify` on the web write path by passing the pre-serialized string through the adapter contract.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: All 136 existing tests pass (including both draft persistence suites). No new tests added — the shared composable is fully exercised through the existing adapter-level tests.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
