### PR TITLE
feat(markdown): add keyboard-first command palette

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,14 +4,5 @@ This repository versions release-bearing artifacts with Changesets.
 
 Allowed package scopes:
 
-- `@markdown-studio/desktop` for desktop-specific behavior, packaging changes, and shared app changes that are not desktop-specific.
+- `@markdown-studio/desktop` for desktop-specific behavior, packaging changes, and shared app changes that are not desktop-specific, but that are still shipped with the desktop app.
 - `markdown-studio` for the published npm package and browser launcher behavior. It is affected from changes in `@markdown-studio/app`, `@markdown-studio/web` when they are not desktop-specific.
-
-Internal workspaces are intentionally excluded from release scopes:
-
-- `@markdown-studio/app`
-- `@markdown-studio/web`
-- `@markdown-studio/desktop-contract`
-- `@markdown-studio/landing`
-
-When shared code changes affect both shipped artifacts, include both allowed package names in the same changeset.

--- a/.changeset/command-palette.md
+++ b/.changeset/command-palette.md
@@ -1,0 +1,10 @@
+---
+'@markdown-studio/desktop': minor
+'markdown-studio': minor
+---
+
+Add a keyboard-first command palette to the editor workspace
+
+- Add searchable workspace commands for document, editor, view, theme, export, and examples workflows
+- Add an accessible command palette overlay with keyboard navigation, disabled reasons, and current-state markers
+- Add shortcut label formatting and focused command palette tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Changesets Validation
 
-- `@markdown-studio/desktop` for desktop-specific behavior, packaging changes, and shared app changes that are not desktop-specific.
+- `@markdown-studio/desktop` for desktop-specific behavior, packaging changes, and shared app changes that are not desktop-specific, but that are still shipped with the desktop app.
 - `markdown-studio` for the published npm package and browser launcher behavior. It is affected from changes in `@markdown-studio/app`, `@markdown-studio/web` when they are not desktop-specific.
 - Use the following format for generated changesets:
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,6 +7,14 @@ Markdown Studio is a Markdown editing context centered on authoring, previewing,
 **Markdown Document**:
 User-authored Markdown content plus its document identity, such as a display name or saved file path.
 
+**Command**:
+A searchable user intention that invokes an existing **Editor Workspace** capability.
+_Avoid_: action, handler, event
+
+**Command Palette**:
+A searchable **Editor Workspace** surface for discovering and invoking **Commands**.
+_Avoid_: launcher, quick actions
+
 **Document Identity**:
 The name or saved file path Markdown Studio uses to recognize a **Markdown Document** across editing, saving, restoring, and exporting.
 _Avoid_: display name, current path
@@ -57,6 +65,8 @@ _Avoid_: route, layout
 ## Relationships
 
 - A **Markdown Document** may have a **Document Identity**.
+- A **Command Palette** belongs to the **Editor Workspace**.
+- A **Command** invokes an existing **Editor Workspace** capability.
 - A **Markdown Document** can produce one or more **Rendered Markdown Documents**.
 - A **Markdown Document** may contain zero or more **Embedded Diagrams**.
 - An **Editor Workspace** has at most one active **Markdown Document**.

--- a/cypress/e2e/markdown-studio.cy.ts
+++ b/cypress/e2e/markdown-studio.cy.ts
@@ -403,6 +403,33 @@ describe('Markdown Studio responsive shell', () => {
     })
   })
 
+  it('opens the command palette and runs Find from the editor', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/')
+
+    cy.get('textarea').trigger('keydown', { ctrlKey: true, key: 'k' })
+    cy.get('.command-palette__input').should('be.focused').type('find{enter}')
+
+    cy.get('.command-palette').should('not.exist')
+    cy.get('.find-replace-bar__input').first().should('be.focused')
+  })
+
+  it('scrolls the command palette results with arrow-key navigation', () => {
+    cy.viewport(1280, 900)
+    cy.visit('/')
+
+    cy.get('textarea').trigger('keydown', { ctrlKey: true, key: 'k' })
+    cy.get('.command-palette__input').should('be.focused')
+
+    for (let index = 0; index < 12; index += 1) {
+      cy.get('.command-palette__input').type('{downArrow}')
+    }
+
+    cy.get('.command-palette__results').should(($results) => {
+      expect(($results[0] as HTMLElement).scrollTop).to.be.greaterThan(0)
+    })
+  })
+
   it('focuses the editor at the clicked preview block in split mode', () => {
     cy.viewport(1280, 900)
     cy.visit('/')

--- a/packages/app/src/features/markdown/components/CommandPalette.vue
+++ b/packages/app/src/features/markdown/components/CommandPalette.vue
@@ -1,0 +1,328 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, useTemplateRef, watch } from 'vue'
+
+import type { CommandPaletteResult, EditorWorkspaceCommand } from '../types/commands'
+
+import CommandPaletteItem from './CommandPaletteItem.vue'
+
+interface Props {
+  activeCommandId: EditorWorkspaceCommand['id'] | null
+  isOpen: boolean
+  query: string
+  results: CommandPaletteResult[]
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  close: []
+  execute: [command?: EditorWorkspaceCommand]
+  moveActive: [delta: number]
+  'update:query': [value: string]
+}>()
+
+const inputRef = useTemplateRef<HTMLInputElement>('input')
+const panelRef = useTemplateRef<HTMLElement>('panel')
+const resultsRef = useTemplateRef<HTMLElement>('results')
+let previousFocus: Element | null = null
+
+const groupedResults = computed(() => {
+  const groups: { group: string; results: CommandPaletteResult[] }[] = []
+
+  for (const result of props.results) {
+    const existingGroup = groups.find((group) => group.group === result.command.group)
+    if (existingGroup) {
+      existingGroup.results.push(result)
+      continue
+    }
+
+    groups.push({ group: result.command.group, results: [result] })
+  }
+
+  return groups
+})
+const activeDescendant = computed(() =>
+  props.activeCommandId ? getCommandOptionId(props.activeCommandId) : undefined,
+)
+
+function closeWithFocusRestore(): void {
+  emit('close')
+  if (previousFocus instanceof HTMLElement) {
+    previousFocus.focus()
+  }
+}
+
+function getCommandOptionId(commandId: EditorWorkspaceCommand['id']): string {
+  return `command-palette-option-${commandId.replaceAll(':', '-')}`
+}
+
+function handleBackdropPointerdown(event: PointerEvent): void {
+  if (event.target === event.currentTarget) {
+    closeWithFocusRestore()
+  }
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeWithFocusRestore()
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    emit('moveActive', 1)
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    emit('moveActive', -1)
+    return
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    emit('execute')
+    return
+  }
+
+  if (event.key === 'Tab') {
+    trapFocus(event)
+  }
+}
+
+function trapFocus(event: KeyboardEvent): void {
+  const focusable = panelRef.value?.querySelectorAll<HTMLElement>(
+    'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  )
+  if (!focusable?.length) {
+    event.preventDefault()
+    return
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (!first || !last) {
+    event.preventDefault()
+    return
+  }
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+    return
+  }
+
+  if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+watch(
+  () => props.isOpen,
+  async (isOpen) => {
+    if (!isOpen) return
+
+    previousFocus = document.activeElement
+    await nextTick()
+    inputRef.value?.focus()
+  },
+)
+
+watch(
+  () => props.activeCommandId,
+  async (activeCommandId) => {
+    if (!props.isOpen || !activeCommandId) return
+
+    await nextTick()
+    const activeOption = resultsRef.value?.querySelector<HTMLElement>(
+      `#${CSS.escape(getCommandOptionId(activeCommandId))}`,
+    )
+    activeOption?.scrollIntoView({ block: 'nearest' })
+  },
+)
+
+function handleDocumentKeydown(event: KeyboardEvent): void {
+  if (!props.isOpen) return
+  if (panelRef.value?.contains(event.target as Node)) return
+
+  handleKeydown(event)
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleDocumentKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleDocumentKeydown)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="command-palette">
+      <div
+        v-if="isOpen"
+        class="command-palette"
+        role="presentation"
+        @pointerdown="handleBackdropPointerdown"
+      >
+        <section
+          ref="panel"
+          class="command-palette__panel"
+          role="dialog"
+          aria-label="Command Palette"
+          aria-modal="true"
+        >
+          <input
+            ref="input"
+            class="command-palette__input"
+            :aria-activedescendant="activeDescendant"
+            aria-controls="command-palette-listbox"
+            autocomplete="off"
+            placeholder="Search commands"
+            role="combobox"
+            spellcheck="false"
+            type="search"
+            :value="query"
+            @input="emit('update:query', ($event.target as HTMLInputElement).value)"
+            @keydown="handleKeydown"
+          />
+
+          <div
+            id="command-palette-listbox"
+            ref="results"
+            class="command-palette__results"
+            role="listbox"
+            aria-label="Commands"
+          >
+            <p v-if="results.length === 0" class="command-palette__empty">No commands found</p>
+            <template v-for="group in groupedResults" :key="group.group">
+              <div class="command-palette__group" role="presentation">{{ group.group }}</div>
+              <button
+                v-for="{ command } in group.results"
+                :id="getCommandOptionId(command.id)"
+                :key="command.id"
+                class="command-palette__option"
+                :disabled="command.disabledReason !== null"
+                role="option"
+                type="button"
+                :aria-disabled="command.disabledReason !== null"
+                :aria-selected="activeCommandId === command.id"
+                @click="emit('execute', command)"
+              >
+                <CommandPaletteItem
+                  :command="command"
+                  :is-active="activeCommandId === command.id"
+                />
+              </button>
+            </template>
+          </div>
+        </section>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.command-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: min(10vh, 72px) 18px 18px;
+  background: rgba(20, 18, 14, 0.28);
+}
+
+.command-palette__panel {
+  width: min(620px, 100%);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 24px 70px rgba(17, 15, 12, 0.24);
+}
+
+.command-palette__input {
+  width: 100%;
+  height: 52px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  outline: none;
+  background: var(--surface);
+  color: var(--text);
+  padding: 0 16px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+}
+
+.command-palette__input::placeholder {
+  color: var(--text-faint);
+}
+
+.command-palette__results {
+  max-height: min(420px, 58vh);
+  overflow: auto;
+  padding: 8px;
+}
+
+.command-palette__group {
+  padding: 10px 10px 5px;
+  color: var(--text-faint);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.command-palette__option {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.command-palette__option:disabled {
+  cursor: not-allowed;
+}
+
+.command-palette__option:focus {
+  outline: none;
+}
+
+.command-palette__empty {
+  margin: 0;
+  padding: 22px 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.command-palette-enter-active,
+.command-palette-leave-active {
+  transition: opacity 0.12s ease;
+}
+
+.command-palette-enter-active .command-palette__panel,
+.command-palette-leave-active .command-palette__panel {
+  transition: transform 0.12s ease;
+}
+
+.command-palette-enter-from,
+.command-palette-leave-to {
+  opacity: 0;
+}
+
+.command-palette-enter-from .command-palette__panel,
+.command-palette-leave-to .command-palette__panel {
+  transform: translateY(-8px);
+}
+</style>

--- a/packages/app/src/features/markdown/components/CommandPaletteItem.vue
+++ b/packages/app/src/features/markdown/components/CommandPaletteItem.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { formatShortcutLabel } from '@/utils/shortcutLabel'
+
+import type { EditorWorkspaceCommand } from '../types/commands'
+
+interface Props {
+  command: EditorWorkspaceCommand
+  isActive?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isActive: false,
+})
+
+const shortcutLabel = computed(() =>
+  props.command.shortcut ? formatShortcutLabel(props.command.shortcut) : '',
+)
+</script>
+
+<template>
+  <div
+    class="command-palette-item"
+    :class="{
+      'command-palette-item--active': isActive,
+      'command-palette-item--disabled': command.disabledReason !== null,
+    }"
+  >
+    <span class="command-palette-item__label">{{ command.title }}</span>
+    <span v-if="command.isCurrent" class="command-palette-item__meta">Current</span>
+    <span v-if="shortcutLabel" class="command-palette-item__shortcut">{{ shortcutLabel }}</span>
+    <span v-if="command.disabledReason" class="command-palette-item__reason">
+      {{ command.disabledReason }}
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.command-palette-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 10px;
+  border-radius: 7px;
+  color: var(--text);
+}
+
+.command-palette-item--active {
+  background: var(--panel);
+}
+
+.command-palette-item--disabled {
+  color: color-mix(in srgb, var(--text) 54%, transparent);
+}
+
+.command-palette-item__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.command-palette-item__meta,
+.command-palette-item__shortcut {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 5px;
+  color: var(--text-muted);
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.command-palette-item__meta {
+  font-family: 'DM Sans', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.command-palette-item__reason {
+  grid-column: 1 / -1;
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1.35;
+}
+</style>

--- a/packages/app/src/features/markdown/composables/__tests__/useCommandPalette.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useCommandPalette.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+
+import type { EditorWorkspaceCommand } from '../../types/commands'
+
+import { useCommandPalette } from '../useCommandPalette'
+
+function createCommand(
+  input: Partial<EditorWorkspaceCommand> & Pick<EditorWorkspaceCommand, 'id' | 'title'>,
+): EditorWorkspaceCommand {
+  return {
+    disabledReason: null,
+    group: 'Document',
+    run: vi.fn(),
+    ...input,
+  }
+}
+
+describe('useCommandPalette', () => {
+  it('resets query and activates the first enabled command when opened', () => {
+    const palette = useCommandPalette({
+      commands: computed(() => [
+        createCommand({
+          disabledReason: 'Unavailable',
+          id: 'document:open',
+          title: 'Open Document...',
+        }),
+        createCommand({ id: 'editor:find', title: 'Find' }),
+      ]),
+    })
+
+    palette.setQuery('find')
+    palette.open()
+
+    expect(palette.query.value).toBe('')
+    expect(palette.isOpen.value).toBe(true)
+    expect(palette.activeCommandId.value).toBe('editor:find')
+  })
+
+  it('ranks exact title, prefix, contains, then keyword matches', () => {
+    const palette = useCommandPalette({
+      commands: computed(() => [
+        createCommand({ id: 'workspace:keyword', keywords: ['find'], title: 'Open Samples' }),
+        createCommand({ id: 'workspace:contains', title: 'Advanced Find Tools' }),
+        createCommand({ id: 'workspace:prefix', title: 'Find Again' }),
+        createCommand({ id: 'editor:find', title: 'Find' }),
+      ]),
+    })
+
+    palette.setQuery('find')
+
+    expect(palette.results.value.map(({ command }) => command.id)).toEqual([
+      'editor:find',
+      'workspace:prefix',
+      'workspace:contains',
+      'workspace:keyword',
+    ])
+  })
+
+  it('skips disabled commands during keyboard navigation and execution', async () => {
+    const firstRun = vi.fn()
+    const secondRun = vi.fn()
+    const palette = useCommandPalette({
+      commands: computed(() => [
+        createCommand({ id: 'workspace:first', run: firstRun, title: 'First' }),
+        createCommand({
+          disabledReason: 'Unavailable',
+          id: 'workspace:disabled',
+          title: 'Disabled',
+        }),
+        createCommand({ id: 'workspace:second', run: secondRun, title: 'Second' }),
+      ]),
+    })
+
+    palette.open()
+    palette.moveActive(1)
+    await palette.execute()
+
+    expect(palette.activeCommandId.value).toBe('workspace:second')
+    expect(firstRun).not.toHaveBeenCalled()
+    expect(secondRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes before awaiting command execution', async () => {
+    let wasOpenDuringRun = true
+    const palette = useCommandPalette({
+      commands: computed(() => [
+        createCommand({
+          id: 'workspace:async',
+          run: async () => {
+            wasOpenDuringRun = palette.isOpen.value
+          },
+          title: 'Async',
+        }),
+      ]),
+    })
+
+    palette.open()
+    await palette.execute()
+
+    expect(wasOpenDuringRun).toBe(false)
+    expect(palette.isOpen.value).toBe(false)
+  })
+})

--- a/packages/app/src/features/markdown/composables/useCommandPalette.ts
+++ b/packages/app/src/features/markdown/composables/useCommandPalette.ts
@@ -1,0 +1,111 @@
+import { computed, type ComputedRef, readonly, shallowRef } from 'vue'
+
+import { formatShortcutLabel } from '@/utils/shortcutLabel'
+
+import type { EditorWorkspaceCommand } from '../types/commands'
+
+interface UseCommandPaletteOptions {
+  commands: ComputedRef<EditorWorkspaceCommand[]>
+}
+
+export function useCommandPalette(options: UseCommandPaletteOptions) {
+  const isOpen = shallowRef(false)
+  const query = shallowRef('')
+  const activeCommandId = shallowRef<EditorWorkspaceCommand['id'] | null>(null)
+
+  const results = computed(() =>
+    options.commands.value
+      .map((command, index) => ({ command, index, score: scoreCommand(command, query.value) }))
+      .filter((result) => result.score >= 0)
+      .sort((first, second) => first.score - second.score || first.index - second.index)
+      .map(({ command, score }) => ({ command, score })),
+  )
+  const enabledResults = computed(() =>
+    results.value.filter(({ command }) => command.disabledReason === null),
+  )
+  const activeResult = computed(() => {
+    const activeId = activeCommandId.value
+    return enabledResults.value.find(({ command }) => command.id === activeId) ?? null
+  })
+
+  function open(): void {
+    query.value = ''
+    isOpen.value = true
+    activeCommandId.value = enabledResults.value[0]?.command.id ?? null
+  }
+
+  function close(): void {
+    isOpen.value = false
+  }
+
+  function setQuery(value: string): void {
+    query.value = value
+    activeCommandId.value = enabledResults.value[0]?.command.id ?? null
+  }
+
+  function moveActive(delta: number): void {
+    const enabled = enabledResults.value
+    if (enabled.length === 0) {
+      activeCommandId.value = null
+      return
+    }
+
+    const currentIndex = enabled.findIndex(({ command }) => command.id === activeCommandId.value)
+    const startIndex = currentIndex >= 0 ? currentIndex : 0
+    const nextIndex = (startIndex + delta + enabled.length) % enabled.length
+    activeCommandId.value = enabled[nextIndex]?.command.id ?? null
+  }
+
+  async function execute(command = activeResult.value?.command): Promise<void> {
+    if (!command || command.disabledReason !== null) {
+      return
+    }
+
+    close()
+    await command.run()
+  }
+
+  return {
+    activeCommandId: readonly(activeCommandId),
+    activeResult,
+    close,
+    execute,
+    isOpen: readonly(isOpen),
+    moveActive,
+    open,
+    query: readonly(query),
+    results,
+    setQuery,
+  }
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function scoreCommand(command: EditorWorkspaceCommand, query: string): number {
+  const normalizedQuery = normalize(query)
+  if (!normalizedQuery) {
+    return 0
+  }
+
+  const title = normalize(command.title)
+  if (title === normalizedQuery) return 1
+  if (title.startsWith(normalizedQuery)) return 2
+  if (title.includes(normalizedQuery)) return 3
+
+  const searchable = [
+    command.group,
+    ...(command.keywords ?? []),
+    ...(command.shortcut
+      ? [
+          formatShortcutLabel(command.shortcut, 'mac'),
+          formatShortcutLabel(command.shortcut, 'other'),
+        ]
+      : []),
+  ]
+    .map(normalize)
+    .join(' ')
+
+  return searchable.includes(normalizedQuery) ? 4 : -1
+}

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceCommands.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceCommands.ts
@@ -1,0 +1,165 @@
+import { computed, type ComputedRef } from 'vue'
+
+import type { EditorWorkspaceCommand } from '../types/commands'
+import type { EditorWorkspaceController } from '../types/workspace'
+
+export function useEditorWorkspaceCommands(
+  workspace: EditorWorkspaceController,
+): ComputedRef<EditorWorkspaceCommand[]> {
+  return computed(() => {
+    const state = workspace.state
+    const canOpenDocuments = state.canOpenDocuments.value
+    const canSaveDocuments = state.canSaveDocuments.value
+    const canExportPdf = state.canExportPdf.value
+    const pdfExportUnavailableReason = state.pdfExportUnavailableReason.value
+    const availableModes = state.availableModes.value
+    const viewMode = state.viewMode.value
+    const theme = state.theme.value
+
+    const commands: EditorWorkspaceCommand[] = [
+      {
+        disabledReason: null,
+        group: 'Document',
+        id: 'workspace:document:new',
+        keywords: ['clear', 'blank', 'new file'],
+        run: workspace.document.startNew,
+        title: 'New Markdown Document',
+      },
+      {
+        disabledReason: canOpenDocuments ? null : 'Open is available in the desktop app.',
+        group: 'Document',
+        id: 'document:open',
+        keywords: ['file', 'load'],
+        run: workspace.document.open,
+        shortcut: ['Mod', 'O'],
+        title: 'Open Document...',
+      },
+      {
+        disabledReason: canSaveDocuments ? null : 'Save is available in the desktop app.',
+        group: 'Document',
+        id: 'document:save',
+        keywords: ['write', 'file'],
+        run: workspace.document.save,
+        shortcut: ['Mod', 'S'],
+        title: 'Save Document',
+      },
+      {
+        disabledReason: canSaveDocuments ? null : 'Save As is available in the desktop app.',
+        group: 'Document',
+        id: 'document:saveAs',
+        keywords: ['rename', 'copy', 'file'],
+        run: workspace.document.saveAs,
+        shortcut: ['Mod', 'Shift', 'S'],
+        title: 'Save Document As...',
+      },
+      {
+        disabledReason: null,
+        group: 'Document',
+        id: 'document:exportHtml',
+        keywords: ['download', 'html'],
+        run: workspace.export.html,
+        title: 'Export HTML...',
+      },
+      {
+        disabledReason: canExportPdf
+          ? null
+          : pdfExportUnavailableReason || 'PDF export is unavailable.',
+        group: 'Document',
+        id: 'document:exportPdf',
+        keywords: ['download', 'pdf', 'print'],
+        run: workspace.export.pdf,
+        title: 'Export PDF...',
+      },
+      {
+        disabledReason: null,
+        group: 'Editor',
+        id: 'editor:find',
+        keywords: ['search'],
+        run: workspace.find.open,
+        shortcut: ['Mod', 'F'],
+        title: 'Find',
+      },
+      {
+        disabledReason: null,
+        group: 'Editor',
+        id: 'editor:replace',
+        keywords: ['search', 'substitute'],
+        run: workspace.find.openReplace,
+        shortcut: ['Mod', 'H'],
+        title: 'Replace',
+      },
+      {
+        disabledReason: null,
+        group: 'View',
+        id: 'workspace:view:editor',
+        isCurrent: viewMode === 'editor',
+        keywords: ['markdown', 'write'],
+        run: () => workspace.editor.setViewMode('editor'),
+        title: 'Show Editor',
+      },
+      {
+        disabledReason: null,
+        group: 'View',
+        id: 'workspace:view:split',
+        isCurrent: viewMode === 'split',
+        keywords: ['preview', 'split', 'side by side'],
+        run: () => workspace.editor.setViewMode('split'),
+        title: 'Show Editor and Live Preview',
+      },
+      {
+        disabledReason: null,
+        group: 'View',
+        id: 'workspace:view:preview',
+        isCurrent: viewMode === 'preview',
+        keywords: ['rendered', 'preview'],
+        run: () => workspace.editor.setViewMode('preview'),
+        title: 'Show Live Preview',
+      },
+      {
+        disabledReason: null,
+        group: 'View',
+        id: 'workspace:theme:light',
+        isCurrent: theme === 'light',
+        keywords: ['light mode'],
+        run: () => workspace.editor.setTheme({ origin: getViewportCenter(), theme: 'light' }),
+        title: 'Use Light Theme',
+      },
+      {
+        disabledReason: null,
+        group: 'View',
+        id: 'workspace:theme:dark',
+        isCurrent: theme === 'dark',
+        keywords: ['dark mode'],
+        run: () => workspace.editor.setTheme({ origin: getViewportCenter(), theme: 'dark' }),
+        title: 'Use Dark Theme',
+      },
+      {
+        disabledReason: null,
+        group: 'Examples',
+        id: 'workspace:examples:open',
+        keywords: ['samples', 'templates'],
+        run: workspace.examples.open,
+        title: 'Open Example Documents...',
+      },
+    ]
+
+    return commands.filter((command) => {
+      if (command.id === 'workspace:view:editor') return availableModes.includes('editor')
+      if (command.id === 'workspace:view:split') return availableModes.includes('split')
+      if (command.id === 'workspace:view:preview') return availableModes.includes('preview')
+
+      return true
+    })
+  })
+}
+
+function getViewportCenter(): { x: number; y: number } {
+  if (typeof window === 'undefined') {
+    return { x: 0, y: 0 }
+  }
+
+  return {
+    x: window.innerWidth / 2,
+    y: window.innerHeight / 2,
+  }
+}

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -70,6 +70,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     restoreWorkspaceDraft: restoreDocumentWorkspaceDraft,
     savedContent,
     saveDocument,
+    saveDocumentAs,
     startNewDocument,
     statusText,
   } = useDocumentSession({
@@ -351,6 +352,10 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     await performDocumentAction(saveDocument)
   }
 
+  async function saveWorkspaceDocumentAs(): Promise<void> {
+    await performDocumentAction(saveDocumentAs)
+  }
+
   async function startNew(): Promise<void> {
     await performDocumentAction(async () => {
       await startNewDocument()
@@ -488,6 +493,13 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       return
     }
 
+    // Consumed so Cmd/Ctrl+K doesn't fall through to find/replace handling;
+    // the command palette opens via a capture-phase handler in the view.
+    if (hasCommandModifier && normalizedKey === 'k') {
+      event.preventDefault()
+      return
+    }
+
     if (!isFindReplaceOpen.value) {
       return
     }
@@ -549,6 +561,9 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       },
       async save(): Promise<void> {
         await saveWorkspaceDocument()
+      },
+      async saveAs(): Promise<void> {
+        await saveWorkspaceDocumentAs()
       },
       async startNew(): Promise<void> {
         await startNew()

--- a/packages/app/src/features/markdown/types/commands.ts
+++ b/packages/app/src/features/markdown/types/commands.ts
@@ -1,0 +1,19 @@
+import type { AppCommand } from '@markdown-studio/desktop-contract/types'
+
+export type CommandGroup = 'Document' | 'Editor' | 'Examples' | 'View'
+
+export interface CommandPaletteResult {
+  command: EditorWorkspaceCommand
+  score: number
+}
+
+export interface EditorWorkspaceCommand {
+  disabledReason: null | string
+  group: CommandGroup
+  id: `workspace:${string}` | AppCommand
+  isCurrent?: boolean
+  keywords?: string[]
+  run(): Promise<void> | void
+  shortcut?: string[]
+  title: string
+}

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -47,6 +47,7 @@ export interface EditorWorkspaceController {
     open(): Promise<void>
     restoreDraft(): Promise<void>
     save(): Promise<void>
+    saveAs(): Promise<void>
     startNew(): Promise<void>
   }
   editor: {

--- a/packages/app/src/utils/__tests__/shortcutLabel.spec.ts
+++ b/packages/app/src/utils/__tests__/shortcutLabel.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatShortcutLabel } from '../shortcutLabel'
+
+describe('formatShortcutLabel', () => {
+  it('formats macOS shortcut labels with glyphs', () => {
+    expect(formatShortcutLabel(['Mod', 'Shift', 'S'], 'mac')).toBe('⌘⇧S')
+  })
+
+  it('formats Windows and Linux shortcut labels with text', () => {
+    expect(formatShortcutLabel(['Mod', 'Shift', 'S'], 'other')).toBe('Ctrl+Shift+S')
+  })
+})

--- a/packages/app/src/utils/shortcutLabel.ts
+++ b/packages/app/src/utils/shortcutLabel.ts
@@ -1,0 +1,36 @@
+export function formatShortcutLabel(keys: string[], platform = getShortcutPlatform()): string {
+  const isMac = platform === 'mac'
+
+  return keys.map((key) => formatShortcutKey(key, isMac)).join(isMac ? '' : '+')
+}
+
+export function getShortcutPlatform(): 'mac' | 'other' {
+  if (typeof navigator === 'undefined') {
+    return 'other'
+  }
+
+  const platform = navigator.platform || ''
+  return /mac|iphone|ipad|ipod/i.test(platform) ? 'mac' : 'other'
+}
+
+function formatShortcutKey(key: string, isMac: boolean): string {
+  const normalizedKey = key.toLowerCase()
+
+  if (normalizedKey === 'mod') {
+    return isMac ? '⌘' : 'Ctrl'
+  }
+
+  if (normalizedKey === 'shift') {
+    return isMac ? '⇧' : 'Shift'
+  }
+
+  if (normalizedKey === 'alt') {
+    return isMac ? '⌥' : 'Alt'
+  }
+
+  if (normalizedKey === 'enter') {
+    return isMac ? '↩' : 'Enter'
+  }
+
+  return key.length === 1 ? key.toUpperCase() : key
+}

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -3,6 +3,7 @@ import { useTemplateRef, watch } from 'vue'
 
 import type { EditorScrollPayload } from '@/features/markdown/types'
 
+import CommandPalette from '@/features/markdown/components/CommandPalette.vue'
 import EditorPane from '@/features/markdown/components/EditorPane.vue'
 import ExamplesModal from '@/features/markdown/components/ExamplesModal.vue'
 import PreviewPane from '@/features/markdown/components/PreviewPane.vue'
@@ -10,9 +11,13 @@ import PwaBanner from '@/features/markdown/components/PwaBanner.vue'
 import StatusBar from '@/features/markdown/components/StatusBar.vue'
 import Toolbar from '@/features/markdown/components/Toolbar.vue'
 import UpdateBanner from '@/features/markdown/components/UpdateBanner.vue'
+import { useCommandPalette } from '@/features/markdown/composables/useCommandPalette'
+import { useEditorWorkspaceCommands } from '@/features/markdown/composables/useEditorWorkspaceCommands'
 import { useEditorWorkspaceController } from '@/features/markdown/composables/useEditorWorkspaceController'
 
 const workspace = useEditorWorkspaceController()
+const commands = useEditorWorkspaceCommands(workspace)
+const commandPalette = useCommandPalette({ commands })
 const {
   availableModes,
   bannerStatus,
@@ -140,10 +145,23 @@ function handleStartNewDocument(): void {
     console.error('Failed to start new document:', error)
   })
 }
+
+function handleWorkspaceKeydown(event: KeyboardEvent): void {
+  const hasCommandModifier = event.metaKey || event.ctrlKey
+
+  if (!hasCommandModifier || event.key.toLowerCase() !== 'k' || event.isComposing) {
+    return
+  }
+
+  event.preventDefault()
+  if (!isExamplesModalOpen.value) {
+    commandPalette.open()
+  }
+}
 </script>
 
 <template>
-  <div class="markdown-studio" :class="bodyClasses">
+  <div class="markdown-studio" :class="bodyClasses" @keydown.capture="handleWorkspaceKeydown">
     <Toolbar
       :available-modes="availableModes"
       :can-export-pdf="canExportPdf"
@@ -221,6 +239,17 @@ function handleStartNewDocument(): void {
       :is-open="isExamplesModalOpen"
       @close="workspace.examples.close"
       @select="workspace.document.loadExample"
+    />
+
+    <CommandPalette
+      :active-command-id="commandPalette.activeCommandId.value"
+      :is-open="commandPalette.isOpen.value"
+      :query="commandPalette.query.value"
+      :results="commandPalette.results.value"
+      @close="commandPalette.close"
+      @execute="commandPalette.execute"
+      @move-active="commandPalette.moveActive"
+      @update:query="commandPalette.setQuery"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

Add a keyboard-first command palette to the editor workspace, opened via `Cmd/Ctrl+K`. The palette exposes 14 searchable commands covering document, editor, view, theme, export, and examples workflows with deterministic ranking, disabled-command visibility, and full keyboard accessibility.

## Type of Change

- [x] New feature

## Screenshots

<!-- UI is an overlay — best verified interactively or via Cypress -->

| Before | After |
| ------ | ----- |
| No command palette | Searchable command palette with grouped results, disabled reasons, current-state markers, and shortcut labels |

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit` — 146/146 tests including new `useCommandPalette.spec.ts` and `shortcutLabel.spec.ts`
- [x] E2E tests pass: `pnpm test:e2e` — added Cypress smoke for Cmd+K → Find and arrow-key scroll
- [x] Manual testing notes: Verified `pnpm lint`, `pnpm type-check`, `pnpm format`, and `pnpm changeset:validate-scopes` all pass clean

## Related Issue

N/A

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
