### PR TITLE
ci(release): fix homebrew tap push authentication

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -166,4 +166,5 @@ jobs:
           git add -A
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "Update markdown-studio to ${VERSION}"
-          git -c http.extraheader="AUTHORIZATION: bearer ${TAP_TOKEN}" push origin HEAD:main
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/theoklitosBam7/homebrew-tap.git"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

Fixes Homebrew tap updates in the desktop release workflow by authenticating the `homebrew-tap` push with a tokenized remote URL instead of an `http.extraheader` bearer header, which was failing when pushing cask updates after a release.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| N/A — CI workflow change | N/A |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [ ] Unit tests pass: `pnpm test:unit` (not applicable — workflow-only change)
- [ ] E2E tests pass: `pnpm test:e2e` (not applicable)
- [x] Manual testing notes:
  - Verify the `Update Homebrew Cask` step in `release-desktop.yml` sets `origin` to `https://x-access-token:${TAP_TOKEN}@github.com/theoklitosBam7/homebrew-tap.git` before `git push`
  - Confirm on the next desktop release that the workflow can push the cask commit to `homebrew-tap` `main`

## Related Issue

N/A — small CI fix for Homebrew tap push authentication.

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality (not applicable — workflow-only)
- [ ] Lint and type-check pass: `pnpm lint && pnpm type-check` (not applicable)
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
