### PR TITLE
feat(landing-page): add Homebrew install option to landing page

### DIFF
--- a/apps/landing-page/index.html
+++ b/apps/landing-page/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or download the desktop app for macOS."
+      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or install the desktop app on macOS with Homebrew."
     />
     <meta
       name="keywords"
@@ -17,7 +17,7 @@
     <meta property="og:title" content="Markdown Studio - Write Markdown. See It Live." />
     <meta
       property="og:description"
-      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or download the desktop app for macOS."
+      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or install the desktop app on macOS with Homebrew."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://markdownstudio.eu/" />
@@ -27,7 +27,7 @@
     <meta name="twitter:title" content="Markdown Studio - Write Markdown. See It Live." />
     <meta
       name="twitter:description"
-      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or download the desktop app for macOS."
+      content="A beautiful, modern Markdown editor with live preview, Mermaid diagram support, and export to standalone HTML and print-ready PDF. Use it in your browser as a PWA, or install the desktop app on macOS with Homebrew."
     />
 
     <title>Markdown Studio - Write Markdown. See It Live.</title>

--- a/apps/landing-page/src/components/CTASection.ts
+++ b/apps/landing-page/src/components/CTASection.ts
@@ -9,27 +9,27 @@ export function CTASection(): string {
         </p>
         
         <div class="cta-buttons">
-          <a href="https://github.com/theoklitosBam7/markdown-studio/releases/latest"
-             class="btn btn-primary btn-lg"
-             target="_blank"
-             rel="noopener noreferrer">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-            Download for macOS
-          </a>
+          <div class="cta-button-wrapper">
+            <button class="btn btn-code btn-lg" type="button" data-action="copy-brew">
+              <span class="npm-command">brew install --cask theoklitosBam7/tap/markdown-studio</span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+            </button>
+          </div>
 
-          <button class="btn btn-code btn-lg" type="button" data-action="copy-npm">
-            <span class="npm-command">npx markdown-studio@latest</span>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-          </button>
+          <div class="cta-button-wrapper">
+            <button class="btn btn-code btn-lg" type="button" data-action="copy-npm">
+              <span class="npm-command">npx markdown-studio@latest</span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+            </button>
+            <p class="cta-button-hint">Runs locally, opens your browser automatically</p>
+          </div>
         </div>
-        <p class="cta-hint">Runs a local server and opens your browser automatically</p>
         
         <a href="https://github.com/theoklitosBam7/markdown-studio" 
            class="cta-github" 

--- a/apps/landing-page/src/components/Features.ts
+++ b/apps/landing-page/src/components/Features.ts
@@ -43,9 +43,10 @@ const features: Feature[] = [
     title: 'PWA Support',
   },
   {
-    description: 'Download the desktop app for macOS and enjoy a native editing experience.',
+    description:
+      'Install the desktop app on macOS for a dedicated editing environment with full file system integration.',
     icon: '🖥️',
-    title: 'Native Desktop App',
+    title: 'Desktop App',
   },
   {
     description:

--- a/apps/landing-page/src/components/Hero.ts
+++ b/apps/landing-page/src/components/Hero.ts
@@ -19,31 +19,31 @@ export function Hero(): string {
           <p class="hero-subtitle">
             A beautiful, distraction-free editor with live preview, Mermaid diagram support,
             and built-in export to standalone HTML and print-ready PDF. Use it in your browser,
-            install as a PWA, or download the desktop app for macOS.
+            install as a PWA, or install the desktop app on macOS with Homebrew.
           </p>
 
           <div class="hero-ctas">
-            <a href="https://github.com/theoklitosBam7/markdown-studio/releases/latest"
-               class="btn btn-primary btn-lg"
-               target="_blank"
-               rel="noopener noreferrer">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                <polyline points="7 10 12 15 17 10"/>
-                <line x1="12" y1="15" x2="12" y2="3"/>
-              </svg>
-              Download for macOS
-            </a>
+            <div class="hero-cta-wrapper">
+              <button class="btn btn-code btn-lg" type="button" data-action="copy-brew">
+                <span class="npm-command">brew install --cask theoklitosBam7/tap/markdown-studio</span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+            </div>
 
-            <button class="btn btn-code btn-lg" type="button" data-action="copy-npm">
-              <span class="npm-command">npx markdown-studio@latest</span>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-              </svg>
-            </button>
+            <div class="hero-cta-wrapper">
+              <button class="btn btn-code btn-lg" type="button" data-action="copy-npm">
+                <span class="npm-command">npx markdown-studio@latest</span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                </svg>
+              </button>
+              <p class="hero-cta-hint">Runs locally, opens your browser automatically</p>
+            </div>
           </div>
-          <p class="hero-ctas-hint">Runs locally and opens your browser automatically</p>
         </div>
       </div>
 

--- a/apps/landing-page/src/components/UsageModes.ts
+++ b/apps/landing-page/src/components/UsageModes.ts
@@ -10,28 +10,30 @@ export function UsageModes(): string {
 
         <div class="usage-grid">
           <!-- Desktop App -->
-          <div class="usage-card">
+          <div class="usage-card recommended">
             <div class="usage-icon">💻</div>
-            <h3 class="usage-title">Download for macOS</h3>
-            <p class="usage-description">Native app with full file system integration. Best for daily use on Apple Silicon Macs.</p>
+            <h3 class="usage-title">macOS Desktop</h3>
+            <p class="usage-description">Install the desktop app on macOS for a dedicated editing environment with full file system integration.</p>
+            <button class="btn btn-code usage-cta" type="button" data-action="copy-brew">
+              <span class="npm-command">brew install --cask theoklitosBam7/tap/markdown-studio</span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+              </svg>
+            </button>
             <a href="https://github.com/theoklitosBam7/markdown-studio/releases/latest"
-               class="btn btn-primary usage-cta"
+               class="usage-fallback-link"
                target="_blank"
                rel="noopener noreferrer">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                <polyline points="7 10 12 15 17 10"/>
-                <line x1="12" y1="15" x2="12" y2="3"/>
-              </svg>
-              Download
+              or download the DMG directly
             </a>
           </div>
 
           <!-- PWA -->
-          <div class="usage-card recommended">
+          <div class="usage-card">
             <div class="usage-icon">📲</div>
             <h3 class="usage-title">Install as Web App</h3>
-            <p class="usage-description">Works offline, auto-updates, feels like a native app. Available on any OS with Chrome, Edge, or Safari.</p>
+            <p class="usage-description">Works offline, auto-updates, feels like a standalone app. Available on any OS with Chrome, Edge, or Safari.</p>
             <a href="https://pwa.markdownstudio.eu/"
                class="btn btn-primary usage-cta"
                target="_blank"

--- a/apps/landing-page/src/main.ts
+++ b/apps/landing-page/src/main.ts
@@ -8,13 +8,14 @@ import './styles/components.css'
 import './styles/main.css'
 
 const npmCommand = 'npx markdown-studio@latest'
+const brewCommand = 'brew install --cask theoklitosBam7/tap/markdown-studio'
 
-async function copyNpmCommand(button: HTMLElement): Promise<void> {
+async function copyToClipboard(text: string, button: HTMLElement): Promise<void> {
   try {
-    await navigator.clipboard.writeText(npmCommand)
+    await navigator.clipboard.writeText(text)
     updateCopyButtonLabel(button, 'Copied!')
   } catch (error) {
-    console.error('Failed to copy npm command to clipboard:', error)
+    console.error('Failed to copy command to clipboard:', error)
     updateCopyButtonLabel(button, 'Copy failed')
   }
 }
@@ -24,9 +25,16 @@ function handleCopyCommandClick(event: MouseEvent): void {
   if (!(target instanceof Element)) return
 
   const button = target.closest<HTMLElement>('[data-action="copy-npm"]')
-  if (!button) return
+  if (button) {
+    void copyToClipboard(npmCommand, button)
+    return
+  }
 
-  void copyNpmCommand(button)
+  const brewButton = target.closest<HTMLElement>('[data-action="copy-brew"]')
+  if (brewButton) {
+    void copyToClipboard(brewCommand, brewButton)
+    return
+  }
 }
 
 // Render the app
@@ -48,7 +56,7 @@ function updateCopyButtonLabel(button: HTMLElement, label: string): void {
   const commandSpan = button.querySelector<HTMLElement>('.npm-command')
   if (!commandSpan) return
 
-  const originalText = commandSpan.textContent ?? npmCommand
+  const originalText = commandSpan.textContent ?? ''
   commandSpan.textContent = label
 
   window.setTimeout(() => {

--- a/apps/landing-page/src/styles/components.css
+++ b/apps/landing-page/src/styles/components.css
@@ -57,16 +57,27 @@
 .hero-ctas {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-6);
   align-items: center;
   justify-content: center;
 }
 
-@media (min-width: 640px) {
-  .hero-ctas {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
+.hero-cta-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  max-width: 440px;
+}
+
+.hero-cta-wrapper .btn {
+  width: 100%;
+}
+
+.hero-cta-hint {
+  font-size: 0.8rem;
+  color: var(--text-faint);
 }
 
 .hero-ctas-hint {
@@ -384,17 +395,35 @@
 .cta-buttons {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-6);
   align-items: center;
   justify-content: center;
   margin-bottom: var(--space-12);
 }
 
-@media (min-width: 640px) {
-  .cta-buttons {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
+.cta-button-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  max-width: 440px;
+}
+
+.cta-button-wrapper .btn {
+  width: 100%;
+}
+
+.cta-button-hint {
+  font-size: 0.8rem;
+  color: var(--text-faint);
+}
+
+.cta-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: calc(-1 * var(--space-8));
+  margin-bottom: var(--space-8);
 }
 
 .cta-github {
@@ -606,6 +635,17 @@
 .usage-cta {
   width: 100%;
   justify-content: center;
+}
+
+.usage-fallback-link {
+  display: inline-block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: var(--space-3);
+}
+
+.usage-fallback-link:hover {
+  color: var(--accent);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

Replace direct download links for the macOS desktop app with a Homebrew cask install copy-to-clipboard action across the landing page. Also refactors the CTA layout to pair each install method with its own hint text, and updates copy throughout to reference Homebrew installation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes:
  - Homebrew install button copies `brew install --cask theoklitosBam7/tap/markdown-studio` to clipboard
  - Npx install button continues to work as before
  - Fallback DMG download link works in UsageModes section
  - Responsive layout wraps CTA buttons correctly at mobile widths

## Related Issue

N/A

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [x] UI changes have screenshots (if applicable)
