### PR TITLE
chore(release): adopt reader-facing scopes and namespaced label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report something that isn't working correctly
 title: 'bug: '
-labels: ['bug']
+labels: ['type:bug']
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: 'feat: '
-labels: ['enhancement']
+labels: ['type:feature']
 assignees: []
 body:
   - type: markdown

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,155 @@
+# Canonical label definitions for markdown-studio.
+#
+# Labels are lightweight navigation and triage signals. Keep issue templates
+# minimal, and do not use labels for resolution outcomes.
+
+labels:
+  # Type: what kind of work this is.
+  - name: type:bug
+    color: '5B5BD6'
+    description: Something is not working correctly
+
+  - name: type:feature
+    color: '5B5BD6'
+    description: New feature or user-facing improvement
+
+  - name: type:refactor
+    color: '5B5BD6'
+    description: Code restructuring without behavior change
+
+  - name: type:docs
+    color: '5B5BD6'
+    description: Documentation improvements
+
+  - name: type:test
+    color: '5B5BD6'
+    description: Test coverage or test infrastructure
+
+  - name: type:ci
+    color: '5B5BD6'
+    description: CI/CD configuration or automation
+
+  - name: type:chore
+    color: '5B5BD6'
+    description: Maintenance work that does not fit another type
+
+  - name: type:dependencies
+    color: '5B5BD6'
+    description: Dependency updates
+
+  - name: type:rfc
+    color: '5B5BD6'
+    description: Request for comments or design discussion
+
+  # Area: product capability or stable maintenance concern.
+  - name: area:editor-workspace
+    color: '138A72'
+    description: Core editing workspace behavior
+
+  - name: area:live-preview
+    color: '138A72'
+    description: Preview pane behavior and synchronization
+
+  - name: area:markdown-rendering
+    color: '138A72'
+    description: Markdown parsing and rendered output
+
+  - name: area:embedded-diagrams
+    color: '138A72'
+    description: Mermaid and other embedded diagram behavior
+
+  - name: area:source-navigation
+    color: '138A72'
+    description: Source mapping, scrolling, and navigation
+
+  - name: area:workspace-drafts
+    color: '138A72'
+    description: Draft persistence and restoration
+
+  - name: area:file-operations
+    color: '138A72'
+    description: Opening, saving, importing, or managing files
+
+  - name: area:export
+    color: '138A72'
+    description: Exporting documents or generated output
+
+  - name: area:command-palette
+    color: '138A72'
+    description: Command palette actions and shortcuts
+
+  - name: area:examples
+    color: '138A72'
+    description: Example documents and starter content
+
+  - name: area:release
+    color: '138A72'
+    description: Release automation, packaging, or notes
+
+  - name: area:docs
+    color: '138A72'
+    description: Project documentation
+
+  - name: area:accessibility
+    color: '138A72'
+    description: Accessibility behavior or affordances
+
+  - name: area:ui
+    color: '138A72'
+    description: Visual design, layout, or interaction polish
+
+  - name: area:performance
+    color: '138A72'
+    description: Responsiveness, rendering speed, or resource usage
+
+  - name: area:testing
+    color: '138A72'
+    description: Test strategy, fixtures, or coverage
+
+  # Runtime: where the behavior is observed.
+  - name: runtime:web
+    color: 'B56B00'
+    description: Browser or PWA runtime behavior
+
+  - name: runtime:desktop
+    color: 'B56B00'
+    description: Electron desktop runtime behavior
+
+  - name: runtime:cli
+    color: 'B56B00'
+    description: Browser launcher CLI behavior
+
+  # Status: current actionability, not final resolution.
+  - name: status:needs-info
+    color: 'C24162'
+    description: More information is needed before this can move forward
+
+  - name: status:accepted
+    color: 'C24162'
+    description: Accepted and ready for implementation
+
+  - name: status:blocked
+    color: 'C24162'
+    description: Blocked by another task, dependency, or decision
+
+  # Priority: relative urgency.
+  - name: priority:high
+    color: 'C0362C'
+    description: Important and should be prioritized
+
+  - name: priority:normal
+    color: 'D29922'
+    description: Normal priority
+
+  - name: priority:low
+    color: '6A737D'
+    description: Low priority or nice-to-have
+
+  # Contributor signals: keep familiar GitHub community labels unprefixed.
+  - name: good first issue
+    color: '7057FF'
+    description: Good for newcomers with clear implementation guidance
+
+  - name: help wanted
+    color: '008672'
+    description: Extra attention or external contribution is welcome

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,6 +36,8 @@ jobs:
               - 'cypress/**/*'
               - '**/__tests__/**'
               - '**/*.spec.ts'
+              - '**/*.spec.mjs'
+              - 'scripts/**/*'
               - 'pnpm-workspace.yaml'
               - 'package.json'
               - '**/vite.config.ts'
@@ -182,6 +184,9 @@ jobs:
 
       - name: Type check
         run: pnpm type-check
+
+      - name: Run script tests
+        run: pnpm test:scripts
 
       - name: Run unit tests
         run: pnpm test:unit

--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ GitHub Release notes are generated from the artifact changelogs, not from GitHub
 
 - `desktop-v*` releases use the matching version section from `apps/desktop/CHANGELOG.md`
 - `npm-v*` releases use the matching version section from `packages/cli/CHANGELOG.md`
-- the generated `Commits by scope` section groups commit subjects into these release-note scopes: `app`, `ci`, `cli`, `desktop`, `electron`, `export`, `landing-page`, and `markdown`
-- alias scopes such as `workflows`, `markdown-editor`, and `useDocumentActions` are normalized into the stable buckets above
+- the generated `Commits by scope` section groups commit subjects into reader-facing release-note scopes such as `editor`, `preview`, `diagrams`, `export`, `file-operations`, `command-palette`, `workspace-drafts`, `ui`, `performance`, `accessibility`, `desktop`, `web`, `cli`, `release`, `testing`, and `docs`
+- alias scopes such as `app`, `markdown`, `electron`, `workflows`, `markdown-editor`, and `useDocumentActions` are normalized into the stable buckets above
+- desktop and npm release notes filter commits after scope normalization so runtime-specific and unknown `other` scopes do not leak into unrelated artifacts
 - `chore(release): ...` commits are intentionally excluded from generated release notes
 
 Prereleases should be prepared through Changesets prerelease mode. The manual publish workflows read the existing manifest versions and publish prereleases to the appropriate channels automatically.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "preview": "pnpm --filter @markdown-studio/web preview",
     "preview:desktop": "pnpm --filter @markdown-studio/desktop preview",
     "test:unit": "pnpm -r test",
+    "test:scripts": "vitest run scripts/",
     "prepare": "cypress install",
     "generate-pwa-assets": "pwa-assets-generator",
     "generate-desktop-icons": "node scripts/generate-desktop-icons.mjs",
@@ -75,6 +76,7 @@
     "sharp": "^0.34.5",
     "start-server-and-test": "^3.0.4",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "vue-tsc": "catalog:"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@24.12.3)(jsdom@28.1.0)(vite@8.0.11(@types/node@24.12.3)(jiti@2.7.0)(terser@5.47.1)(yaml@2.8.4))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.8(typescript@5.9.3)

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -9,26 +9,48 @@ import { promisify } from 'node:util'
 const rootDir = fileURLToPath(new URL('..', import.meta.url))
 const execFile = promisify(execFileCallback)
 export const allowedReleaseNoteScopes = [
-  'app',
-  'ci',
-  'cli',
-  'common',
+  'editor',
+  'preview',
+  'diagrams',
+  'export',
+  'file-operations',
+  'command-palette',
+  'workspace-drafts',
+  'ui',
+  'performance',
+  'accessibility',
   'desktop',
-  'electron',
-  'landing-page',
-  'markdown',
   'web',
+  'cli',
+  'release',
+  'testing',
+  'docs',
+  'general',
+  'other',
 ]
 
-const artifactRelevantScopes = {
-  desktop: ['app', 'cli', 'common', 'desktop', 'electron', 'markdown'],
-  npm: ['app', 'cli', 'common', 'markdown', 'web'],
+const scopeSortOrder = new Map(allowedReleaseNoteScopes.map((scope, index) => [scope, index]))
+
+const artifactExcludedScopes = {
+  desktop: ['cli', 'other', 'web'],
+  npm: ['desktop', 'other'],
 }
 
 const releaseNoteScopeAliases = new Map([
-  ['markdown-editor', 'markdown'],
-  ['workflows', 'ci'],
+  ['a11y', 'accessibility'],
+  ['app', 'editor'],
+  ['ci', 'release'],
+  ['documentation', 'docs'],
+  ['electron', 'desktop'],
+  ['markdown-editor', 'editor'],
+  ['markdown', 'preview'],
+  ['test', 'testing'],
+  ['tests', 'testing'],
+  ['useDocumentActions', 'file-operations'],
+  ['workflows', 'release'],
 ])
+
+const scopeTitleOverrides = { cli: 'CLI', ui: 'UI' }
 
 export function extractChangelogSection(source, version) {
   const heading = `## ${version}`
@@ -145,7 +167,9 @@ export function groupCommitSubjectsByScope(subjects, artifactType = null) {
   }
 
   return [...groups.entries()]
-    .sort(([leftScope], [rightScope]) => leftScope.localeCompare(rightScope))
+    .sort(
+      ([leftScope], [rightScope]) => scopeSortOrder.get(leftScope) - scopeSortOrder.get(rightScope),
+    )
     .map(([scope, entries]) => ({
       entries,
       scope,
@@ -191,7 +215,7 @@ export function renderCommitsByScopeSection(subjects, artifactType = null) {
   const lines = ['## Commits by scope']
 
   for (const group of groups) {
-    lines.push('', `### ${group.scope}`)
+    lines.push('', `### ${formatReleaseNoteScopeTitle(group.scope)}`)
 
     for (const entry of group.entries) {
       lines.push(`- ${entry.subject}`)
@@ -231,15 +255,16 @@ export function shouldIncludeCommitSubject(subject, artifactType = null) {
   const entry = parseConventionalCommitSubject(subject)
 
   if (entry.type === 'chore' && entry.rawScope === 'release') return false
-  if (entry.scope === 'landing-page' || entry.scope === 'ci') return false
 
-  // Filter by artifact type if specified - only include relevant scopes
-  if (artifactType && artifactRelevantScopes[artifactType]) {
-    const relevantScopes = artifactRelevantScopes[artifactType]
-    if (!relevantScopes.includes(entry.scope)) return false
-  }
+  if (artifactType && artifactExcludedScopes[artifactType]?.includes(entry.scope)) return false
 
   return true
+}
+
+function formatReleaseNoteScopeTitle(scope) {
+  return (
+    scopeTitleOverrides[scope] ?? scope.replace(/-/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
+  )
 }
 
 function normalizeReleaseNoteScope(scope) {

--- a/scripts/generate-release-notes.spec.mjs
+++ b/scripts/generate-release-notes.spec.mjs
@@ -64,14 +64,24 @@ describe('renderReleaseNotes', () => {
 describe('parseConventionalCommitSubject', () => {
   it('exposes the supported release-note scopes', () => {
     expect(allowedReleaseNoteScopes).toEqual([
-      'app',
-      'ci',
-      'cli',
-      'desktop',
-      'electron',
+      'editor',
+      'preview',
+      'diagrams',
       'export',
-      'landing-page',
-      'markdown',
+      'file-operations',
+      'command-palette',
+      'workspace-drafts',
+      'ui',
+      'performance',
+      'accessibility',
+      'desktop',
+      'web',
+      'cli',
+      'release',
+      'testing',
+      'docs',
+      'general',
+      'other',
     ])
   })
 
@@ -99,7 +109,7 @@ describe('parseConventionalCommitSubject', () => {
     expect(parseConventionalCommitSubject('fix(workflows): clean up release flow')).toEqual({
       description: 'clean up release flow',
       rawScope: 'workflows',
-      scope: 'ci',
+      scope: 'release',
       subject: 'fix(workflows): clean up release flow',
       type: 'fix',
     })
@@ -107,8 +117,24 @@ describe('parseConventionalCommitSubject', () => {
     expect(parseConventionalCommitSubject('fix(markdown-editor): improve toolbar')).toEqual({
       description: 'improve toolbar',
       rawScope: 'markdown-editor',
-      scope: 'markdown',
+      scope: 'editor',
       subject: 'fix(markdown-editor): improve toolbar',
+      type: 'fix',
+    })
+
+    expect(parseConventionalCommitSubject('fix(useDocumentActions): handle save errors')).toEqual({
+      description: 'handle save errors',
+      rawScope: 'useDocumentActions',
+      scope: 'file-operations',
+      subject: 'fix(useDocumentActions): handle save errors',
+      type: 'fix',
+    })
+
+    expect(parseConventionalCommitSubject('fix(ci): remove redundant token')).toEqual({
+      description: 'remove redundant token',
+      rawScope: 'ci',
+      scope: 'release',
+      subject: 'fix(ci): remove redundant token',
       type: 'fix',
     })
   })
@@ -120,6 +146,14 @@ describe('parseConventionalCommitSubject', () => {
       scope: 'other',
       subject: 'fix(router): clean up history mode',
       type: 'fix',
+    })
+
+    expect(parseConventionalCommitSubject('feat(landing-page): update hero section')).toEqual({
+      description: 'update hero section',
+      rawScope: 'landing-page',
+      scope: 'other',
+      subject: 'feat(landing-page): update hero section',
+      type: 'feat',
     })
   })
 
@@ -144,29 +178,34 @@ describe('shouldIncludeCommitSubject', () => {
     expect(shouldIncludeCommitSubject('chore(cli): standardize package metadata')).toBe(true)
     expect(shouldIncludeCommitSubject('feat(export): add PDF export')).toBe(true)
   })
+
+  it('includes ci-scoped commits under the release scope instead of filtering them', () => {
+    expect(shouldIncludeCommitSubject('fix(ci): remove redundant token')).toBe(true)
+    expect(shouldIncludeCommitSubject('fix(ci): remove redundant token', 'desktop')).toBe(true)
+    expect(shouldIncludeCommitSubject('fix(ci): remove redundant token', 'npm')).toBe(true)
+  })
+
+  it('filters artifact-specific commits after aliasing scopes', () => {
+    expect(shouldIncludeCommitSubject('fix(electron): handle native save dialog', 'desktop')).toBe(
+      true,
+    )
+    expect(shouldIncludeCommitSubject('fix(web): refresh service worker', 'desktop')).toBe(false)
+    expect(shouldIncludeCommitSubject('fix(electron): handle native save dialog', 'npm')).toBe(
+      false,
+    )
+    expect(shouldIncludeCommitSubject('fix(router): clean up history mode', 'npm')).toBe(false)
+  })
 })
 
 describe('groupCommitSubjectsByScope', () => {
   it('groups and sorts commit subjects by scope', () => {
     expect(
       groupCommitSubjectsByScope([
-        'fix(ci): remove redundant token',
+        'fix(workflows): remove redundant token',
         'feat(export): add PDF export',
         'feat: update og url',
       ]),
     ).toEqual([
-      {
-        entries: [
-          {
-            description: 'remove redundant token',
-            rawScope: 'ci',
-            scope: 'ci',
-            subject: 'fix(ci): remove redundant token',
-            type: 'fix',
-          },
-        ],
-        scope: 'ci',
-      },
       {
         entries: [
           {
@@ -182,6 +221,18 @@ describe('groupCommitSubjectsByScope', () => {
       {
         entries: [
           {
+            description: 'remove redundant token',
+            rawScope: 'workflows',
+            scope: 'release',
+            subject: 'fix(workflows): remove redundant token',
+            type: 'fix',
+          },
+        ],
+        scope: 'release',
+      },
+      {
+        entries: [
+          {
             description: 'update og url',
             rawScope: null,
             scope: 'general',
@@ -193,6 +244,32 @@ describe('groupCommitSubjectsByScope', () => {
       },
     ])
   })
+
+  it('excludes unknown scopes from artifact-specific groups', () => {
+    expect(
+      groupCommitSubjectsByScope(
+        [
+          'fix(router): clean up history mode',
+          'fix(electron): handle native save dialog',
+          'fix(web): refresh service worker',
+        ],
+        'desktop',
+      ),
+    ).toEqual([
+      {
+        entries: [
+          {
+            description: 'handle native save dialog',
+            rawScope: 'electron',
+            scope: 'desktop',
+            subject: 'fix(electron): handle native save dialog',
+            type: 'fix',
+          },
+        ],
+        scope: 'desktop',
+      },
+    ])
+  })
 })
 
 describe('renderCommitsByScopeSection', () => {
@@ -200,20 +277,39 @@ describe('renderCommitsByScopeSection', () => {
     expect(
       renderCommitsByScopeSection([
         'chore(release): version packages',
-        'fix(ci): remove redundant token',
         'feat(export): add PDF export',
+        'fix(workflows): remove redundant token',
         'feat: update og url',
       ]),
     ).toBe(`## Commits by scope
 
-### ci
-- fix(ci): remove redundant token
-
-### export
+### Export
 - feat(export): add PDF export
 
-### general
+### Release
+- fix(workflows): remove redundant token
+
+### General
 - feat: update og url`)
+  })
+
+  it('renders display headings and artifact filtering together', () => {
+    expect(
+      renderCommitsByScopeSection(
+        [
+          'fix(useDocumentActions): handle save errors',
+          'fix(electron): handle native save dialog',
+          'fix(web): refresh service worker',
+        ],
+        'npm',
+      ),
+    ).toBe(`## Commits by scope
+
+### File operations
+- fix(useDocumentActions): handle save errors
+
+### Web
+- fix(web): refresh service worker`)
   })
 
   it('renders an empty-state message when no commits are available', () => {


### PR DESCRIPTION
## Summary

Replace implementation-package release-note scopes (app, ci, electron, markdown, landing-page) with reader-facing capability scopes (editor, preview, diagrams, export, file-operations, etc.). Introduce a namespaced GitHub label taxonomy in `.github/labels.yml` as the canonical source of truth, and migrate issue templates from legacy `bug`/`enhancement` labels to `type:bug`/`type:feature`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [x] Workflow
- [x] Test

## Screenshots

N/A — no UI changes.

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [x] Script tests pass: `pnpm test:scripts` (28 tests)
- [x] Format passes: `pnpm format`
- [x] Lint passes: `pnpm lint`
- [x] Type-check passes: `pnpm type-check`

## Related Issue

N/A

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [x] UI changes have screenshots (if applicable)
