### PR TITLE
chore(labels): add canonical label sync and CI guard

### DIFF
--- a/.github/scripts/sync-labels.rb
+++ b/.github/scripts/sync-labels.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'yaml'
+
+LABELS_FILE = ENV.fetch('LABELS_FILE', '.github/labels.yml')
+REPOSITORY = ENV['GITHUB_REPOSITORY']
+TOKEN = ENV['GITHUB_TOKEN']
+DRY_RUN = ENV.fetch('DRY_RUN', 'false') == 'true'
+DELETE_MISSING = ENV.fetch('DELETE_MISSING', 'false') == 'true'
+VALIDATE_ONLY = ENV.fetch('VALIDATE_ONLY', 'false') == 'true'
+
+def fail_with(message)
+  warn(message)
+  exit(1)
+end
+
+def normalize_color(color)
+  color.to_s.delete_prefix('#').upcase
+end
+
+def normalize_description(description)
+  description.to_s
+end
+
+def label_path(name)
+  URI.encode_www_form_component(name).gsub('+', '%20')
+end
+
+def request(method, path, body = nil)
+  fail_with('GITHUB_REPOSITORY is required unless VALIDATE_ONLY=true.') if REPOSITORY.nil? || REPOSITORY.empty?
+  fail_with('GITHUB_TOKEN is required unless VALIDATE_ONLY=true.') if TOKEN.nil? || TOKEN.empty?
+
+  uri = URI("https://api.github.com/repos/#{REPOSITORY}#{path}")
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+
+  klass = {
+    get: Net::HTTP::Get,
+    post: Net::HTTP::Post,
+    patch: Net::HTTP::Patch,
+    delete: Net::HTTP::Delete,
+  }.fetch(method)
+
+  req = klass.new(uri)
+  req['Accept'] = 'application/vnd.github+json'
+  req['Authorization'] = "Bearer #{TOKEN}"
+  req['User-Agent'] = 'markdown-studio-label-sync'
+  req['X-GitHub-Api-Version'] = '2022-11-28'
+
+  if body
+    req['Content-Type'] = 'application/json'
+    req.body = JSON.generate(body)
+  end
+
+  response = http.request(req)
+  unless response.code.to_i.between?(200, 299)
+    fail_with("GitHub API #{method.upcase} #{path} failed with #{response.code}: #{response.body}")
+  end
+
+  response
+end
+
+def load_desired_labels
+  fail_with("#{LABELS_FILE} does not exist.") unless File.file?(LABELS_FILE)
+
+  raw = YAML.safe_load(File.read(LABELS_FILE), permitted_classes: [], aliases: false)
+  labels = raw.fetch('labels') { fail_with("#{LABELS_FILE} must contain a top-level labels: array.") }
+  fail_with("#{LABELS_FILE} labels: must be an array.") unless labels.is_a?(Array)
+
+  names = {}
+  labels.map.with_index(1) do |label, index|
+    fail_with("Label ##{index} must be a mapping.") unless label.is_a?(Hash)
+
+    name = label['name'].to_s.strip
+    color = normalize_color(label['color'])
+    description = normalize_description(label['description'])
+
+    fail_with("Label ##{index} is missing name.") if name.empty?
+    fail_with("Label #{name.inspect} is duplicated.") if names[name]
+    fail_with("Label #{name.inspect} must use a 6-character hex color.") unless color.match?(/\A[0-9A-F]{6}\z/)
+    fail_with("Label #{name.inspect} description must be 100 characters or less.") if description.length > 100
+
+    names[name] = true
+    { 'name' => name, 'color' => color, 'description' => description }
+  end
+end
+
+def fetch_existing_labels
+  labels = []
+  page = 1
+
+  loop do
+    response = request(:get, "/labels?per_page=100&page=#{page}")
+    batch = JSON.parse(response.body)
+    labels.concat(batch)
+    break if batch.length < 100
+
+    page += 1
+  end
+
+  labels.to_h { |label| [label.fetch('name'), label] }
+end
+
+desired_labels = load_desired_labels
+puts "Validated #{desired_labels.length} labels from #{LABELS_FILE}."
+
+if VALIDATE_ONLY
+  puts 'Validation-only mode; no GitHub API calls were made.'
+  exit(0)
+end
+
+existing_labels = fetch_existing_labels
+desired_names = desired_labels.map { |label| label.fetch('name') }
+
+desired_labels.each do |label|
+  existing = existing_labels[label.fetch('name')]
+  payload = {
+    color: label.fetch('color'),
+    description: label.fetch('description'),
+  }
+
+  if existing.nil?
+    puts "#{DRY_RUN ? 'Would create' : 'Creating'} #{label.fetch('name')}"
+    request(:post, '/labels', payload.merge(name: label.fetch('name'))) unless DRY_RUN
+    next
+  end
+
+  color_changed = normalize_color(existing['color']) != label.fetch('color')
+  description_changed = normalize_description(existing['description']) != label.fetch('description')
+
+  if color_changed || description_changed
+    puts "#{DRY_RUN ? 'Would update' : 'Updating'} #{label.fetch('name')}"
+    request(:patch, "/labels/#{label_path(label.fetch('name'))}", payload) unless DRY_RUN
+  else
+    puts "Unchanged #{label.fetch('name')}"
+  end
+end
+
+missing_labels = existing_labels.keys - desired_names
+if missing_labels.empty?
+  puts 'No labels are missing from the canonical file.'
+elsif DELETE_MISSING
+  missing_labels.each do |name|
+    puts "#{DRY_RUN ? 'Would delete' : 'Deleting'} #{name}"
+    request(:delete, "/labels/#{label_path(name)}") unless DRY_RUN
+  end
+else
+  puts 'Labels absent from the canonical file were left untouched:'
+  missing_labels.sort.each { |name| puts "  - #{name}" }
+end

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,7 @@ jobs:
     name: Detect changed areas
     runs-on: ubuntu-24.04
     outputs:
+      run_label_validation: ${{ steps.compute.outputs.run_label_validation }}
       run_changeset_check: ${{ steps.compute.outputs.run_changeset_check }}
       run_full_workflow: ${{ steps.compute.outputs.run_full_workflow }}
     steps:
@@ -43,6 +44,10 @@ jobs:
               - '**/vite.config.ts'
               - '**/tsconfig.json'
               - '.github/workflows/*.yml'
+            label_taxonomy_changes:
+              - '.github/labels.yml'
+              - '.github/scripts/sync-labels.rb'
+              - '.github/workflows/sync-labels.yml'
 
       - name: Filter release changed paths
         if: github.event_name == 'pull_request'
@@ -82,6 +87,7 @@ jobs:
       - name: Compute workflow scope
         id: compute
         env:
+          LABEL_TAXONOMY_CHANGED: ${{ steps.meaningful_filter.outputs.label_taxonomy_changes }}
           MEANINGFUL_CHANGED: ${{ steps.meaningful_filter.outputs.meaningful_changes }}
           DESKTOP_RELEASE_CHANGED: ${{ steps.release_filter.outputs.desktop_release_changes }}
           WEB_RELEASE_CHANGED: ${{ steps.release_filter.outputs.web_release_changes }}
@@ -89,8 +95,13 @@ jobs:
           APP_RELEASE_CHANGED: ${{ steps.release_filter.outputs.app_release_changes }}
           DESKTOP_CONTRACT_RELEASE_CHANGED: ${{ steps.release_filter.outputs.desktop_contract_release_changes }}
         run: |
+          run_label_validation=false
           run_changeset_check=false
           run_full_workflow=false
+
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "$LABEL_TAXONOMY_CHANGED" = "true" ]; then
+            run_label_validation=true
+          fi
 
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "$MEANINGFUL_CHANGED" = "true" ]; then
             run_full_workflow=true
@@ -106,8 +117,28 @@ jobs:
             run_changeset_check=true
           fi
 
+          echo "run_label_validation=$run_label_validation" >> "$GITHUB_OUTPUT"
           echo "run_changeset_check=$run_changeset_check" >> "$GITHUB_OUTPUT"
           echo "run_full_workflow=$run_full_workflow" >> "$GITHUB_OUTPUT"
+
+  label_taxonomy:
+    name: Label taxonomy validation
+    runs-on: ubuntu-24.04
+    if: needs.changes.outputs.run_label_validation == 'true'
+    needs: changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/labels.yml
+            .github/scripts/sync-labels.rb
+
+      - name: Validate labels
+        env:
+          VALIDATE_ONLY: true
+        run: ruby .github/scripts/sync-labels.rb
 
   changeset_check:
     name: Changeset validation

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,43 @@
+name: Sync labels
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview label changes without writing to GitHub.
+        required: true
+        type: boolean
+        default: true
+      delete_missing:
+        description: Delete labels that are absent from .github/labels.yml.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync repository labels
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github/labels.yml
+            .github/scripts/sync-labels.rb
+
+      - name: Sync labels
+        env:
+          DELETE_MISSING: ${{ inputs.delete_missing }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ruby .github/scripts/sync-labels.rb

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ pnpm build:desktop # Production build
 pnpm dist:mac      # Create macOS distribution package (unsigned)
 ```
 
+## Repository Maintenance
+
+The canonical GitHub label taxonomy lives in `.github/labels.yml`. Labels are
+triage and navigation signals only; they are not release-note inputs.
+
+Maintainers can run the manual **Sync labels** workflow from GitHub Actions to
+apply the taxonomy. Keep `dry_run` enabled for the first run to review the
+planned creates and updates in the logs. Leave `delete_missing` disabled unless
+you have already reviewed legacy labels such as `bug` and `enhancement` and
+intentionally want to remove labels that are absent from `.github/labels.yml`.
+
 ## Features
 
 ### For Writers


### PR DESCRIPTION
## Summary

Add a declarative GitHub label management system. A Ruby script reconciles repository labels against a canonical `.github/labels.yml` file, a manual workflow lets maintainers preview and apply changes, and PR CI now validates the taxonomy when label-related files are touched.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

N/A

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes:
  - Ran `VALIDATE_ONLY=true ruby .github/scripts/sync-labels.rb` — passes
  - Ran `LABELS_FILE=.github/missing-labels.yml ruby .github/scripts/sync-labels.rb` — fails with clear error
  - Ran `ruby -c .github/scripts/sync-labels.rb` — syntax OK
  - Ran `pnpm format`, `pnpm lint`, `pnpm type-check` — all pass

## Related Issue

N/A

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
  - Ruby script tests deferred as a follow-up item
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
