### PR TITLE
feat(ui): add toolbar button for table insertion

### DIFF
--- a/.changeset/toolbar-insert-table-button.md
+++ b/.changeset/toolbar-insert-table-button.md
@@ -1,0 +1,10 @@
+---
+"markdown-studio": minor
+"@markdown-studio/desktop": minor
+---
+
+Add an Insert Table button to the editor toolbar.
+
+- Add a Table toolbar button with grid icon and accessible label
+- Wire the toolbar action to insert a default 3×3 GFM table at the cursor
+- Add unit tests for toolbar emit and Editor Workspace wiring

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -37,6 +37,7 @@ const emit = defineEmits<{
   copy: []
   exportHtml: []
   exportPdf: []
+  insertTable: []
   install: []
   openDocument: []
   openExamples: []
@@ -108,6 +109,10 @@ function handleOutsideClick(event: MouseEvent): void {
   if (!exportMenuRef.value?.contains(event.target as Node)) {
     closeExportMenu()
   }
+}
+
+function insertTable(): void {
+  emit('insertTable')
 }
 
 function install(): void {
@@ -197,6 +202,16 @@ onUnmounted(() => {
               <rect x="9" y="9" width="5" height="5" rx="1" />
             </svg>
             <span>Examples</span>
+          </ToolbarButton>
+
+          <ToolbarButton aria-label="Insert table" @click="insertTable">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <rect x="2" y="2" width="12" height="12" rx="1" />
+              <path d="M2 6h12" />
+              <path d="M6 6v8" />
+              <path d="M10 6v8" />
+            </svg>
+            <span>Table</span>
           </ToolbarButton>
 
           <ToolbarButton @click="clear">

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -49,6 +49,20 @@ describe('Toolbar', () => {
     expect(githubLink.text()).toContain('GitHub')
   })
 
+  it('renders an accessible insert table button that emits insert-table on click', async () => {
+    const wrapper = mountToolbar()
+
+    const tableButton = wrapper.get('button[aria-label="Insert table"]')
+    expect(tableButton.text()).toContain('Table')
+    expect(tableButton.classes()).toContain('toolbar-btn')
+    expect(tableButton.element.closest('.toolbar__actions')).not.toBeNull()
+    expect(tableButton.find('svg').exists()).toBe(true)
+
+    await tableButton.trigger('click')
+
+    expect(wrapper.emitted('insertTable')).toHaveLength(1)
+  })
+
   it('renders keyboard shortcuts as an accessible icon control', async () => {
     const wrapper = mountToolbar()
 

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -200,6 +200,12 @@ function handleFindAction(action: { type: string; value?: unknown }): void {
   }
 }
 
+function handleInsertTable(): void {
+  void workspace.editor.insertTable().catch((error: unknown) => {
+    console.error('Failed to insert table:', error)
+  })
+}
+
 function handleInstall(): void {
   void workspace.toolbar.install().catch((error: unknown) => {
     console.error('Failed to trigger web app install:', error)
@@ -234,6 +240,7 @@ function handleStartNewDocument(): void {
       @open-shortcuts="isShortcutsHelpOpen = true"
       @clear="handleStartNewDocument"
       @copy="workspace.toolbar.copy"
+      @insert-table="handleInsertTable"
       @export-html="handleExportHtml"
       @export-pdf="handleExportPdf"
       @save-document="workspace.document.save"

--- a/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
+++ b/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
@@ -1,0 +1,83 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+import type { AppWindow } from '@/browser-window'
+
+import { resetPwaStateForTests } from '@/composables/usePwa'
+import { resetBrowserDocumentSessionForTests } from '@/features/markdown/composables/useDocumentActions'
+import { generateTableTemplate } from '@/features/markdown/utils/tableTemplate'
+
+import MarkdownStudioView from '../MarkdownStudioView.vue'
+
+async function mountMarkdownStudioView() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        component: MarkdownStudioView,
+        path: '/',
+      },
+    ],
+  })
+
+  await router.push('/')
+  await router.isReady()
+
+  const wrapper = mount(MarkdownStudioView, {
+    attachTo: document.body,
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  return { router, wrapper }
+}
+
+describe('MarkdownStudioView', () => {
+  const appWindow = window as AppWindow
+  const originalDesktop = appWindow.desktop
+  const originalConfirm = window.confirm
+
+  beforeEach(() => {
+    resetBrowserDocumentSessionForTests()
+    resetPwaStateForTests()
+    appWindow.desktop = undefined
+    window.confirm = vi.fn(() => true)
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    resetBrowserDocumentSessionForTests()
+    resetPwaStateForTests()
+    appWindow.desktop = originalDesktop
+    window.confirm = originalConfirm
+    vi.restoreAllMocks()
+  })
+
+  it('inserts a default table when the toolbar insert table button is clicked', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+    const textarea = wrapper.get('textarea').element as HTMLTextAreaElement
+    const contentBeforeInsert = textarea.value
+    const cursorOffset = 12
+    textarea.setSelectionRange(cursorOffset, cursorOffset)
+
+    await wrapper.get('button[aria-label="Insert table"]').trigger('click')
+    await flushPromises()
+
+    const expectedTable = generateTableTemplate({ columns: 3, rows: 3 })
+    const expectedContent =
+      contentBeforeInsert.slice(0, cursorOffset) +
+      expectedTable +
+      contentBeforeInsert.slice(cursorOffset)
+
+    expect(textarea.value).toBe(expectedContent)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Add a visible Insert Table button to the editor toolbar so users can insert a default 3×3 GFM table at the cursor without opening the Command Palette. Wires the toolbar action through `MarkdownStudioView` to the existing `workspace.editor.insertTable()` flow from #81.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes:
  - Click the **Table** button in the desktop toolbar and confirm a 3×3 GFM table is inserted at the cursor
  - Confirm the button shows a grid icon, **Table** label, and `aria-label="Insert table"`
  - Confirm the button appears in the document actions toolbar group (compact and full layouts)

## Related Issue

Closes #82

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)