### PR TITLE
feat(editor): add custom dimension picker for table insertion

### DIFF
--- a/.changeset/custom-table-dimensions.md
+++ b/.changeset/custom-table-dimensions.md
@@ -1,0 +1,11 @@
+---
+"markdown-studio": minor
+"@markdown-studio/desktop": minor
+---
+
+Add custom row and column selection when inserting a table.
+
+- Open a dimension picker with a 3×3 default before inserting a table
+- Choose any size within sensible bounds (1–50 rows and columns)
+- Reach the same picker from the Command Palette and the toolbar button
+- Insert valid GFM table syntax at the cursor position in both web and desktop runtimes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ The supported scopes are defined in `commitlint.config.ts`; prefer those scopes 
   Start with a summary line (no bullet), then a blank line, then unordered list items each beginning with a present-tense verb.
 
 - Run `pnpm changeset:validate-scopes` after you perform changeset actions.
+- Changesets feed Release Notes and should describe user-facing changes only. Avoid implementation details such as "add unit tests", "refactor internal helpers", or other items that do not change the released behavior.
 
 ## Project Snapshot
 

--- a/packages/app/src/components/base/MobileToolbarActions.vue
+++ b/packages/app/src/components/base/MobileToolbarActions.vue
@@ -36,6 +36,7 @@ const emit = defineEmits<{
   copy: []
   exportHtml: []
   exportPdf: []
+  insertTable: []
   install: []
   openDocument: []
   openExamples: []
@@ -87,6 +88,11 @@ const secondaryActions = computed(() => {
       action: () => emit('openExamples'),
       icon: '✨',
       label: 'Load Examples',
+    },
+    {
+      action: () => emit('insertTable'),
+      icon: '▦',
+      label: 'Insert Table',
     },
     {
       action: () => emit('copy'),

--- a/packages/app/src/components/base/Modal.vue
+++ b/packages/app/src/components/base/Modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, useId } from 'vue'
+import { nextTick, onMounted, onUnmounted, useId, useTemplateRef, watch } from 'vue'
 
 interface Props {
   isOpen: boolean
@@ -8,6 +8,8 @@ interface Props {
 
 const props = defineProps<Props>()
 const generatedTitleId = useId()
+const modalRef = useTemplateRef<HTMLElement>('modal')
+let previousFocus: HTMLElement | null = null
 
 const emit = defineEmits<{
   close: []
@@ -25,6 +27,19 @@ function handleKeydown(e: KeyboardEvent): void {
   }
 }
 
+watch(
+  () => props.isOpen,
+  (isOpen) => {
+    if (isOpen) {
+      previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      void nextTick(() => modalRef.value?.focus())
+    } else if (previousFocus) {
+      previousFocus.focus()
+      previousFocus = null
+    }
+  },
+)
+
 onMounted(() => {
   document.addEventListener('keydown', handleKeydown)
 })
@@ -36,7 +51,14 @@ onUnmounted(() => {
 
 <template>
   <div :class="['modal-overlay', { open: props.isOpen }]">
-    <div class="modal" role="dialog" aria-modal="true" :aria-labelledby="titleId">
+    <div
+      ref="modal"
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      :aria-labelledby="titleId"
+    >
       <div class="modal-header">
         <slot name="header" :title-id="titleId" />
         <button class="modal-close" type="button" aria-label="Close dialog" @click="handleClose">
@@ -85,6 +107,10 @@ onUnmounted(() => {
 
 .modal-overlay.open .modal {
   transform: translateY(0);
+}
+
+.modal:focus {
+  outline: none;
 }
 
 .modal-header {

--- a/packages/app/src/components/base/__tests__/MobileToolbarActions.spec.ts
+++ b/packages/app/src/components/base/__tests__/MobileToolbarActions.spec.ts
@@ -93,6 +93,7 @@ describe('MobileToolbarActions', () => {
     expect(actionLabels.some((label) => label?.includes('Save'))).toBe(true)
     expect(actionLabels.some((label) => label?.includes('Install App'))).toBe(true)
     expect(actionLabels.some((label) => label?.includes('Load Examples'))).toBe(true)
+    expect(actionLabels.some((label) => label?.includes('Insert Table'))).toBe(true)
     expect(actionLabels.some((label) => label?.includes('Copy Markdown'))).toBe(true)
     expect(actionLabels.some((label) => label?.includes('Clear Document'))).toBe(true)
     expect(actionLabels.some((label) => label?.includes('Export as HTML'))).toBe(true)
@@ -144,6 +145,20 @@ describe('MobileToolbarActions', () => {
     await saveAction?.dispatchEvent(new MouseEvent('click'))
 
     expect(wrapper.emitted('saveDocument')).toHaveLength(1)
+  })
+
+  it('emits insertTable when Insert Table action is clicked', async () => {
+    const wrapper = mountToolbar()
+
+    const menuButton = document.querySelector('button[aria-label="Menu"]')
+    await menuButton?.dispatchEvent(new MouseEvent('click'))
+
+    const actions = document.querySelectorAll('.mobile-action-sheet__action')
+    const tableAction = Array.from(actions).find((el) => el.textContent?.includes('Insert Table'))
+
+    await tableAction?.dispatchEvent(new MouseEvent('click'))
+
+    expect(wrapper.emitted('insertTable')).toHaveLength(1)
   })
 
   it('does not show Open/Save buttons outside action sheet', () => {

--- a/packages/app/src/features/markdown/components/TableDimensionPicker.vue
+++ b/packages/app/src/features/markdown/components/TableDimensionPicker.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { useTemplateRef } from 'vue'
+
+import Modal from '@/components/base/Modal.vue'
+
+import { TABLE_DIMENSION_BOUNDS } from '../utils/tableDimensions'
+
+interface Props {
+  columns: number
+  isOpen: boolean
+  maxColumns?: number
+  maxRows?: number
+  minColumns?: number
+  minRows?: number
+  rows: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  maxColumns: TABLE_DIMENSION_BOUNDS.maxColumns,
+  maxRows: TABLE_DIMENSION_BOUNDS.maxRows,
+  minColumns: TABLE_DIMENSION_BOUNDS.minColumns,
+  minRows: TABLE_DIMENSION_BOUNDS.minRows,
+})
+
+const emit = defineEmits<{
+  cancel: []
+  confirm: []
+  'update:columns': [columns: number]
+  'update:rows': [rows: number]
+}>()
+const formRef = useTemplateRef<HTMLFormElement>('form')
+
+function handleCancel(): void {
+  emit('cancel')
+}
+
+function handleColumnsInput(event: Event): void {
+  const input = event.target as HTMLInputElement
+  emit('update:columns', input.valueAsNumber)
+}
+
+function handleEnterKey(event: KeyboardEvent): void {
+  event.preventDefault()
+  formRef.value?.requestSubmit()
+}
+
+function handleRowsInput(event: Event): void {
+  const input = event.target as HTMLInputElement
+  emit('update:rows', input.valueAsNumber)
+}
+
+function handleSubmit(): void {
+  emit('confirm')
+}
+</script>
+
+<template>
+  <Modal :is-open="props.isOpen" @close="handleCancel">
+    <template #header="{ titleId }">
+      <h2 :id="titleId">Insert table</h2>
+    </template>
+
+    <form ref="form" class="table-dimension-form" @submit.prevent="handleSubmit">
+      <div class="table-dimension-form__fields">
+        <label class="table-dimension-form__field">
+          <span>Columns</span>
+          <input
+            aria-label="Columns"
+            :max="props.maxColumns"
+            :min="props.minColumns"
+            required
+            type="number"
+            :value="props.columns"
+            @keydown.enter="handleEnterKey"
+            @input="handleColumnsInput"
+          />
+        </label>
+
+        <span class="table-dimension-form__separator" aria-hidden="true">×</span>
+
+        <label class="table-dimension-form__field">
+          <span>Rows</span>
+          <input
+            aria-label="Rows"
+            :max="props.maxRows"
+            :min="props.minRows"
+            required
+            type="number"
+            :value="props.rows"
+            @keydown.enter="handleEnterKey"
+            @input="handleRowsInput"
+          />
+        </label>
+      </div>
+
+      <div class="table-dimension-form__actions">
+        <button class="table-dimension-form__cancel" type="button" @click="handleCancel">
+          Cancel
+        </button>
+        <button class="table-dimension-form__confirm" type="submit">Insert table</button>
+      </div>
+    </form>
+  </Modal>
+</template>
+
+<style scoped>
+.table-dimension-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.table-dimension-form__fields {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 14px;
+}
+
+.table-dimension-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.table-dimension-form__field span {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.table-dimension-form__field input {
+  width: 100%;
+  height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+}
+
+.table-dimension-form__field input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.table-dimension-form__separator {
+  padding-bottom: 10px;
+  color: var(--text-muted);
+  font-size: 15px;
+}
+
+.table-dimension-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.table-dimension-form__actions button {
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 8px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--border);
+}
+
+.table-dimension-form__cancel {
+  background: transparent;
+  color: var(--text);
+}
+
+.table-dimension-form__confirm {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+@media (max-width: 700px) {
+  .table-dimension-form__fields {
+    gap: 10px;
+  }
+}
+</style>

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -151,6 +151,7 @@ onUnmounted(() => {
       @copy="copy"
       @export-html="exportHtml"
       @export-pdf="exportPdf"
+      @insert-table="insertTable"
       @install="install"
       @open-document="openDocument"
       @open-examples="openExamples"

--- a/packages/app/src/features/markdown/components/__tests__/TableDimensionPicker.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/TableDimensionPicker.spec.ts
@@ -1,0 +1,94 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { TABLE_DIMENSION_BOUNDS } from '../../utils/tableDimensions'
+import TableDimensionPicker from '../TableDimensionPicker.vue'
+
+function mountPicker(props: Record<string, unknown> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  return mount(TableDimensionPicker, {
+    attachTo: container,
+    props: {
+      columns: 3,
+      isOpen: true,
+      rows: 3,
+      ...props,
+    },
+  })
+}
+
+describe('TableDimensionPicker', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders row and column inputs with the provided values', () => {
+    const wrapper = mountPicker({ columns: 4, rows: 5 })
+
+    const columnInput = wrapper.get('input[aria-label="Columns"]').element as HTMLInputElement
+    const rowInput = wrapper.get('input[aria-label="Rows"]').element as HTMLInputElement
+
+    expect(columnInput.value).toBe('4')
+    expect(rowInput.value).toBe('5')
+  })
+
+  it('emits update events when input values change', async () => {
+    const wrapper = mountPicker()
+
+    const columnInput = wrapper.get('input[aria-label="Columns"]')
+    await columnInput.setValue('5')
+
+    expect(wrapper.emitted('update:columns')).toEqual([[5]])
+
+    const rowInput = wrapper.get('input[aria-label="Rows"]')
+    await rowInput.setValue('2')
+
+    expect(wrapper.emitted('update:rows')).toEqual([[2]])
+  })
+
+  it('emits confirm when the form is submitted', async () => {
+    const wrapper = mountPicker()
+
+    await wrapper.find('form').trigger('submit')
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('emits cancel when the close button is clicked', async () => {
+    const wrapper = mountPicker()
+
+    await wrapper.find('button[aria-label="Close dialog"]').trigger('click')
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('emits cancel when Escape is pressed', async () => {
+    const wrapper = mountPicker()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }))
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('emits confirm when Enter is pressed from an input', async () => {
+    const wrapper = mountPicker()
+
+    await wrapper.get('input[aria-label="Columns"]').trigger('keydown.enter')
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1)
+  })
+
+  it('reads input min and max attributes from the shared bounds', () => {
+    const wrapper = mountPicker()
+
+    const columnInput = wrapper.get('input[aria-label="Columns"]').element as HTMLInputElement
+    const rowInput = wrapper.get('input[aria-label="Rows"]').element as HTMLInputElement
+
+    expect(columnInput.min).toBe(String(TABLE_DIMENSION_BOUNDS.minColumns))
+    expect(columnInput.max).toBe(String(TABLE_DIMENSION_BOUNDS.maxColumns))
+    expect(rowInput.min).toBe(String(TABLE_DIMENSION_BOUNDS.minRows))
+    expect(rowInput.max).toBe(String(TABLE_DIMENSION_BOUNDS.maxRows))
+  })
+})

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -1,13 +1,18 @@
+import type { VueWrapper } from '@vue/test-utils'
+
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import Toolbar from '../Toolbar.vue'
+
+const wrappers: VueWrapper[] = []
 
 function mountToolbar(overrides: Record<string, unknown> = {}) {
   const container = document.createElement('div')
   document.body.appendChild(container)
 
-  return mount(Toolbar, {
+  const wrapper = mount(Toolbar, {
     attachTo: container,
     props: {
       availableModes: ['editor', 'split', 'preview'],
@@ -20,10 +25,19 @@ function mountToolbar(overrides: Record<string, unknown> = {}) {
       ...overrides,
     },
   })
+
+  wrappers.push(wrapper)
+
+  return wrapper
 }
 
 describe('Toolbar', () => {
-  afterEach(() => {
+  afterEach(async () => {
+    for (const wrapper of wrappers) {
+      wrapper.unmount()
+    }
+    wrappers.length = 0
+    await nextTick()
     document.body.innerHTML = ''
   })
 

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -121,6 +121,24 @@ describe('Toolbar', () => {
     expect(document.querySelector('.mobile-action-sheet-backdrop')).not.toBeNull()
   })
 
+  it('forwards insert-table from mobile action sheet', async () => {
+    const wrapper = mountToolbar({
+      availableModes: ['editor', 'preview'],
+      isMobile: true,
+      viewMode: 'editor',
+    })
+
+    const menuButton = wrapper.find('button[aria-label="Menu"]')
+    await menuButton.trigger('click')
+
+    const actions = document.querySelectorAll('.mobile-action-sheet__action')
+    const tableAction = Array.from(actions).find((el) => el.textContent?.includes('Insert Table'))
+
+    await tableAction?.dispatchEvent(new MouseEvent('click'))
+
+    expect(wrapper.emitted('insertTable')).toHaveLength(1)
+  })
+
   it('hides open and save when document actions are unavailable', () => {
     const wrapper = mountToolbar({
       availableModes: ['editor', 'preview'],

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -505,7 +505,7 @@ describe('useEditorWorkspaceController', () => {
     wrapper.unmount()
   })
 
-  it('inserts a default table template at the cursor position', async () => {
+  it('opens the table dimension picker with a 3x3 default when insertTable is invoked', async () => {
     const { workspace, wrapper } = await mountWorkspace()
     const editor = createEditorAdapter()
     workspace.attach.editor(editor)
@@ -513,15 +513,43 @@ describe('useEditorWorkspaceController', () => {
 
     await workspace.editor.insertTable()
 
+    expect(workspace.state.isTableDimensionPickerOpen.value).toBe(true)
+    expect(workspace.state.tableDimensions.value).toEqual({ columns: 3, rows: 3 })
+    expect(editor.insertText).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('inserts a table with the chosen dimensions when table insertion is confirmed', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+    await flushPromises()
+
+    await workspace.editor.insertTable()
+    workspace.editor.setTableDimensions({ columns: 2, rows: 4 })
+    await workspace.editor.confirmTableInsertion()
+
     expect(editor.insertText).toHaveBeenCalledWith(
-      [
-        '| Header 1 | Header 2 | Header 3 |',
-        '| --- | --- | --- |',
-        '|  |  |  |',
-        '|  |  |  |',
-      ].join('\n'),
+      ['| Header 1 | Header 2 |', '| --- | --- |', '|  |  |', '|  |  |', '|  |  |'].join('\n'),
     )
     expect(editor.focus).toHaveBeenCalled()
+    expect(workspace.state.isTableDimensionPickerOpen.value).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('closes the table dimension picker without inserting when cancelled', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    workspace.attach.editor(editor)
+    await flushPromises()
+
+    await workspace.editor.insertTable()
+    workspace.editor.cancelTableInsertion()
+
+    expect(workspace.state.isTableDimensionPickerOpen.value).toBe(false)
+    expect(editor.insertText).not.toHaveBeenCalled()
 
     wrapper.unmount()
   })

--- a/packages/app/src/features/markdown/composables/__tests__/useTableInsertion.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useTableInsertion.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { shallowRef } from 'vue'
+
+import type { EditorPaneAdapter } from '@/features/markdown/types'
+
+import { generateTableTemplate } from '../../utils/tableTemplate'
+import { useTableInsertion } from '../useTableInsertion'
+
+function createEditorAdapter(): EditorPaneAdapter {
+  return {
+    focus: vi.fn(),
+    focusAtOffset: vi.fn(async () => undefined),
+    focusFindQuery: vi.fn(),
+    getScrollState: vi.fn(() => null),
+    insertText: vi.fn(async () => undefined),
+    replaceAllContent: vi.fn(async () => undefined),
+    replaceRange: vi.fn(async () => undefined),
+    setSelectionRange: vi.fn(async () => undefined),
+  }
+}
+
+describe('useTableInsertion', () => {
+  it('opens the picker with a 3x3 default when insertTable is invoked', () => {
+    const editorPane = shallowRef<EditorPaneAdapter>(createEditorAdapter())
+    const tableInsertion = useTableInsertion({ editorPane })
+
+    tableInsertion.openPicker()
+
+    expect(tableInsertion.isPickerOpen.value).toBe(true)
+    expect(tableInsertion.dimensions.value).toEqual({ columns: 3, rows: 3 })
+  })
+
+  it('inserts a GFM table with the selected dimensions when confirmed', async () => {
+    const editorPane = shallowRef<EditorPaneAdapter>(createEditorAdapter())
+    const tableInsertion = useTableInsertion({ editorPane })
+
+    tableInsertion.openPicker()
+    tableInsertion.setDimensions({ columns: 2, rows: 4 })
+    await tableInsertion.confirmInsertion()
+
+    expect(editorPane.value?.insertText).toHaveBeenCalledWith(
+      generateTableTemplate({ columns: 2, rows: 4 }),
+    )
+    expect(tableInsertion.isPickerOpen.value).toBe(false)
+  })
+
+  it('closes the picker without inserting when cancelled', () => {
+    const editorPane = shallowRef<EditorPaneAdapter>(createEditorAdapter())
+    const tableInsertion = useTableInsertion({ editorPane })
+
+    tableInsertion.openPicker()
+    tableInsertion.closePicker()
+
+    expect(editorPane.value?.insertText).not.toHaveBeenCalled()
+    expect(tableInsertion.isPickerOpen.value).toBe(false)
+  })
+
+  it('clamps dimensions to configured bounds before inserting', async () => {
+    const editorPane = shallowRef<EditorPaneAdapter>(createEditorAdapter())
+    const tableInsertion = useTableInsertion({
+      editorPane,
+      maxColumns: 10,
+      maxRows: 10,
+      minColumns: 1,
+      minRows: 1,
+    })
+
+    tableInsertion.openPicker()
+    tableInsertion.setDimensions({ columns: 0, rows: 100 })
+    await tableInsertion.confirmInsertion()
+
+    expect(editorPane.value?.insertText).toHaveBeenCalledWith(
+      generateTableTemplate({ columns: 1, rows: 10 }),
+    )
+  })
+
+  it('falls back to the minimum dimension when a value is NaN (e.g. an empty input)', async () => {
+    const editorPane = shallowRef<EditorPaneAdapter>(createEditorAdapter())
+    const tableInsertion = useTableInsertion({ editorPane })
+
+    tableInsertion.openPicker()
+    tableInsertion.setDimensions({ columns: Number.NaN, rows: 3 })
+    await tableInsertion.confirmInsertion()
+
+    expect(editorPane.value?.insertText).toHaveBeenCalledWith(
+      generateTableTemplate({ columns: 1, rows: 3 }),
+    )
+  })
+})

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -16,13 +16,13 @@ import type {
   ThemeChangeRequest,
 } from '../types/workspace'
 
-import { generateTableTemplate } from '../utils/tableTemplate'
 import { EXAMPLES } from './examples'
 import { useDesktopDraftPersistence } from './useDesktopDraftPersistence'
 import { useDocumentExport } from './useDocumentExport'
 import { useDocumentSession } from './useDocumentSession'
 import { useFindReplace } from './useFindReplace'
 import { useMarkdownEditor } from './useMarkdownEditor'
+import { useTableInsertion } from './useTableInsertion'
 import { useWebDraftPersistence } from './useWebDraftPersistence'
 
 const MOBILE_BREAKPOINT = 700
@@ -148,6 +148,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     isDirty,
     restoreDraft,
   })
+  const tableInsertion = useTableInsertion({ editorPane })
 
   const bannerStatus = computed(() =>
     updateAvailable.value ? ('update-available' as const) : ('up-to-date' as const),
@@ -416,9 +417,19 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   }
 
   async function insertTable(): Promise<void> {
-    const tableTemplate = generateTableTemplate({ columns: 3, rows: 3 })
-    await editorPane.value?.insertText(tableTemplate)
-    editorPane.value?.focus()
+    tableInsertion.openPicker()
+  }
+
+  function cancelTableInsertion(): void {
+    tableInsertion.closePicker()
+  }
+
+  async function confirmTableInsertion(): Promise<void> {
+    await tableInsertion.confirmInsertion()
+  }
+
+  function setTableDimensions(dimensions: { columns: number; rows: number }): void {
+    tableInsertion.setDimensions(dimensions)
   }
 
   async function start(): Promise<void> {
@@ -534,9 +545,12 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       },
     },
     editor: {
+      cancelTableInsertion,
+      confirmTableInsertion,
       async insertTable(): Promise<void> {
         await insertTable()
       },
+      setTableDimensions,
       async setTheme(request: ThemeChangeRequest) {
         await setWorkspaceTheme(request)
       },
@@ -594,6 +608,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       isExamplesModalOpen,
       isHomebrewInstall: isHomebrewInstallRef,
       isMobile,
+      isTableDimensionPickerOpen: tableInsertion.isPickerOpen,
       pdfExportUnavailableReason,
       pwaBannerStatus,
       renderedHtml,
@@ -602,6 +617,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       sourceMap,
       stats,
       statusText,
+      tableDimensions: tableInsertion.dimensions,
       theme,
       updateInfo,
       viewMode,

--- a/packages/app/src/features/markdown/composables/useTableInsertion.ts
+++ b/packages/app/src/features/markdown/composables/useTableInsertion.ts
@@ -1,0 +1,76 @@
+import type { ShallowRef } from 'vue'
+
+import { readonly, shallowRef } from 'vue'
+
+import type { EditorPaneAdapter, TableDimensions } from '../types/workspace'
+
+import {
+  clampTableDimensions,
+  DEFAULT_TABLE_DIMENSIONS,
+  TABLE_DIMENSION_BOUNDS,
+  type TableDimensionBounds,
+} from '../utils/tableDimensions'
+import { generateTableTemplate } from '../utils/tableTemplate'
+
+export interface TableInsertionApi {
+  closePicker(): void
+  confirmInsertion(): Promise<void>
+  dimensions: Readonly<ShallowRef<TableDimensions>>
+  isPickerOpen: Readonly<ShallowRef<boolean>>
+  openPicker(): void
+  setDimensions(dimensions: TableDimensions): void
+}
+
+export interface UseTableInsertionOptions {
+  defaultDimensions?: TableDimensions
+  editorPane: ShallowRef<EditorPaneAdapter | null>
+  maxColumns?: number
+  maxRows?: number
+  minColumns?: number
+  minRows?: number
+}
+
+export function useTableInsertion(options: UseTableInsertionOptions): TableInsertionApi {
+  const {
+    defaultDimensions = DEFAULT_TABLE_DIMENSIONS,
+    editorPane,
+    maxColumns = TABLE_DIMENSION_BOUNDS.maxColumns,
+    maxRows = TABLE_DIMENSION_BOUNDS.maxRows,
+    minColumns = TABLE_DIMENSION_BOUNDS.minColumns,
+    minRows = TABLE_DIMENSION_BOUNDS.minRows,
+  } = options
+  const bounds: TableDimensionBounds = { maxColumns, maxRows, minColumns, minRows }
+  const isPickerOpen = shallowRef(false)
+  const dimensions = shallowRef<TableDimensions>(clampTableDimensions(defaultDimensions, bounds))
+
+  function openPicker(): void {
+    dimensions.value = clampTableDimensions(defaultDimensions, bounds)
+    isPickerOpen.value = true
+  }
+
+  function closePicker(): void {
+    isPickerOpen.value = false
+  }
+
+  function setDimensions(nextDimensions: TableDimensions): void {
+    dimensions.value = clampTableDimensions(nextDimensions, bounds)
+  }
+
+  async function confirmInsertion(): Promise<void> {
+    const tableTemplate = generateTableTemplate(clampTableDimensions(dimensions.value, bounds))
+    // Close synchronously before the await so a rapid double-submit cannot
+    // insert a second table while the first is still being written.
+    isPickerOpen.value = false
+    await editorPane.value?.insertText(tableTemplate)
+    editorPane.value?.focus()
+  }
+
+  return {
+    closePicker,
+    confirmInsertion,
+    dimensions: readonly(dimensions),
+    isPickerOpen: readonly(isPickerOpen),
+    openPicker,
+    setDimensions,
+  }
+}

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -52,7 +52,10 @@ export interface EditorWorkspaceController {
     startNew(): Promise<void>
   }
   editor: {
+    cancelTableInsertion(): void
+    confirmTableInsertion(): Promise<void>
     insertTable(): Promise<void>
+    setTableDimensions(dimensions: TableDimensions): void
     setTheme(request: ThemeChangeRequest): Promise<void>
     setViewMode(mode: ViewMode): void
     syncPreviewToEditorPosition(payload?: EditorScrollPayload | null): void
@@ -136,6 +139,7 @@ export interface EditorWorkspaceState {
   isExamplesModalOpen: ShallowRef<boolean>
   isHomebrewInstall: Readonly<Ref<boolean>>
   isMobile: ShallowRef<boolean>
+  isTableDimensionPickerOpen: Readonly<Ref<boolean>>
   pdfExportUnavailableReason: Readonly<Ref<string>>
   pwaBannerStatus: Readonly<Ref<'offline-ready' | 'update-available'>>
   renderedHtml: Readonly<Ref<string>>
@@ -144,6 +148,7 @@ export interface EditorWorkspaceState {
   sourceMap: Readonly<Ref<MarkdownSourceMapEntry[]>>
   stats: Readonly<Ref<EditorStats>>
   statusText: Readonly<Ref<string>>
+  tableDimensions: Readonly<Ref<TableDimensions>>
   theme: Readonly<Ref<Theme>>
   updateInfo: Readonly<Ref<null | WorkspaceUpdateInfo>>
   viewMode: Readonly<Ref<ViewMode>>
@@ -151,6 +156,11 @@ export interface EditorWorkspaceState {
 
 export interface PreviewPaneAdapter {
   scrollToSourceOffset(offset: number): void
+}
+
+export interface TableDimensions {
+  columns: number
+  rows: number
 }
 
 export interface ThemeChangeRequest {

--- a/packages/app/src/features/markdown/utils/__tests__/tableDimensions.spec.ts
+++ b/packages/app/src/features/markdown/utils/__tests__/tableDimensions.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clampTableDimensions,
+  DEFAULT_TABLE_DIMENSIONS,
+  TABLE_DIMENSION_BOUNDS,
+} from '../tableDimensions'
+
+describe('tableDimensions', () => {
+  describe('TABLE_DIMENSION_BOUNDS', () => {
+    it('defines a contiguous 1–50 range for rows and columns', () => {
+      expect(TABLE_DIMENSION_BOUNDS).toEqual({
+        maxColumns: 50,
+        maxRows: 50,
+        minColumns: 1,
+        minRows: 1,
+      })
+    })
+  })
+
+  describe('DEFAULT_TABLE_DIMENSIONS', () => {
+    it('defaults to a 3×3 table', () => {
+      expect(DEFAULT_TABLE_DIMENSIONS).toEqual({ columns: 3, rows: 3 })
+    })
+  })
+
+  describe('clampTableDimensions', () => {
+    it('clamps values above the maximum down to the bound', () => {
+      expect(clampTableDimensions({ columns: 999, rows: 100 })).toEqual({ columns: 50, rows: 50 })
+    })
+
+    it('clamps values below the minimum up to the bound', () => {
+      expect(clampTableDimensions({ columns: 0, rows: -5 })).toEqual({ columns: 1, rows: 1 })
+    })
+
+    it('falls back to the minimum for non-finite values such as NaN', () => {
+      expect(clampTableDimensions({ columns: Number.NaN, rows: Number.NaN })).toEqual({
+        columns: 1,
+        rows: 1,
+      })
+    })
+
+    it('truncates fractional values', () => {
+      expect(clampTableDimensions({ columns: 2.9, rows: 4.5 })).toEqual({ columns: 2, rows: 4 })
+    })
+
+    it('honours a custom bounds argument', () => {
+      expect(
+        clampTableDimensions(
+          { columns: 0, rows: 100 },
+          { maxColumns: 10, maxRows: 10, minColumns: 1, minRows: 1 },
+        ),
+      ).toEqual({ columns: 1, rows: 10 })
+    })
+
+    it('leaves in-range integer values unchanged', () => {
+      expect(clampTableDimensions({ columns: 4, rows: 7 })).toEqual({ columns: 4, rows: 7 })
+    })
+  })
+})

--- a/packages/app/src/features/markdown/utils/tableDimensions.ts
+++ b/packages/app/src/features/markdown/utils/tableDimensions.ts
@@ -1,0 +1,46 @@
+import type { TableDimensions } from '../types/workspace'
+
+export interface TableDimensionBounds {
+  maxColumns: number
+  maxRows: number
+  minColumns: number
+  minRows: number
+}
+
+/**
+ * Single source of truth for the dimension bounds enforced by both the
+ * dimension picker (as the input `min`/`max`) and the insertion composable
+ * (as the clamp range). Keep them in sync by reading from here, never by
+ * redeclaring the literals.
+ */
+export const TABLE_DIMENSION_BOUNDS: TableDimensionBounds = {
+  maxColumns: 50,
+  maxRows: 50,
+  minColumns: 1,
+  minRows: 1,
+}
+
+export const DEFAULT_TABLE_DIMENSIONS: TableDimensions = { columns: 3, rows: 3 }
+
+/**
+ * Clamps each dimension into `[min, max]`. Non-finite values (e.g. `NaN` from
+ * an empty `<input type="number">`) fall back to `min`, and fractional values
+ * are truncated, so the result is always a valid table size.
+ */
+export function clampTableDimensions(
+  value: TableDimensions,
+  bounds: TableDimensionBounds = TABLE_DIMENSION_BOUNDS,
+): TableDimensions {
+  return {
+    columns: clampDimension(value.columns, bounds.minColumns, bounds.maxColumns),
+    rows: clampDimension(value.rows, bounds.minRows, bounds.maxRows),
+  }
+}
+
+function clampDimension(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min
+  }
+
+  return Math.max(min, Math.min(max, Math.trunc(value)))
+}

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -10,6 +10,7 @@ import PreviewPane from '@/features/markdown/components/PreviewPane.vue'
 import PwaBanner from '@/features/markdown/components/PwaBanner.vue'
 import ShortcutsHelp from '@/features/markdown/components/ShortcutsHelp.vue'
 import StatusBar from '@/features/markdown/components/StatusBar.vue'
+import TableDimensionPicker from '@/features/markdown/components/TableDimensionPicker.vue'
 import Toolbar from '@/features/markdown/components/Toolbar.vue'
 import UpdateBanner from '@/features/markdown/components/UpdateBanner.vue'
 import { useCommandPalette } from '@/features/markdown/composables/useCommandPalette'
@@ -70,7 +71,10 @@ const bindings = computed<ShortcutBinding[]>(() => [
 ])
 
 const isOverlayOpen = () =>
-  isExamplesModalOpen.value || isShortcutsHelpOpen.value || commandPalette.isOpen.value
+  isExamplesModalOpen.value ||
+  isShortcutsHelpOpen.value ||
+  commandPalette.isOpen.value ||
+  workspace.state.isTableDimensionPickerOpen.value
 
 const { shortcuts } = useShortcuts({
   bindings,
@@ -217,6 +221,20 @@ function handleStartNewDocument(): void {
     console.error('Failed to start new document:', error)
   })
 }
+
+function handleTableDimensionsUpdate(dimensions: { columns: number; rows: number }): void {
+  workspace.editor.setTableDimensions(dimensions)
+}
+
+function handleTableInsertionCancel(): void {
+  workspace.editor.cancelTableInsertion()
+}
+
+function handleTableInsertionConfirm(): void {
+  void workspace.editor.confirmTableInsertion().catch((error: unknown) => {
+    console.error('Failed to confirm table insertion:', error)
+  })
+}
 </script>
 
 <template>
@@ -319,6 +337,28 @@ function handleStartNewDocument(): void {
       :is-open="isShortcutsHelpOpen"
       :shortcuts="shortcuts"
       @close="closeShortcutsHelp"
+    />
+
+    <TableDimensionPicker
+      :columns="workspace.state.tableDimensions.value.columns"
+      :is-open="workspace.state.isTableDimensionPickerOpen.value"
+      :rows="workspace.state.tableDimensions.value.rows"
+      @cancel="handleTableInsertionCancel"
+      @confirm="handleTableInsertionConfirm"
+      @update:columns="
+        (columns) =>
+          handleTableDimensionsUpdate({
+            columns,
+            rows: workspace.state.tableDimensions.value.rows,
+          })
+      "
+      @update:rows="
+        (rows) =>
+          handleTableDimensionsUpdate({
+            columns: workspace.state.tableDimensions.value.columns,
+            rows,
+          })
+      "
     />
   </div>
 </template>

--- a/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
+++ b/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
@@ -10,6 +10,18 @@ import { generateTableTemplate } from '@/features/markdown/utils/tableTemplate'
 
 import MarkdownStudioView from '../MarkdownStudioView.vue'
 
+function dispatchWindowKeydown(key: string, overrides: Partial<KeyboardEventInit> = {}): void {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key, ...overrides }),
+  )
+}
+
+function getButtonByText(text: string): HTMLButtonElement | undefined {
+  return Array.from(document.body.querySelectorAll('button')).find(
+    (button): button is HTMLButtonElement => button.textContent?.trim() === text,
+  )
+}
+
 async function mountMarkdownStudioView() {
   const router = createRouter({
     history: createMemoryHistory(),
@@ -38,6 +50,7 @@ async function mountMarkdownStudioView() {
 
 describe('MarkdownStudioView', () => {
   const appWindow = window as AppWindow
+  const originalCss = window.CSS
   const originalDesktop = appWindow.desktop
   const originalConfirm = window.confirm
 
@@ -45,9 +58,14 @@ describe('MarkdownStudioView', () => {
     resetBrowserDocumentSessionForTests()
     resetPwaStateForTests()
     appWindow.desktop = undefined
+    window.CSS = {
+      ...originalCss,
+      escape: originalCss?.escape ?? ((value: string) => value),
+    }
     window.confirm = vi.fn(() => true)
     window.localStorage.clear()
     window.sessionStorage.clear()
+    HTMLElement.prototype.scrollIntoView ??= vi.fn()
     vi.clearAllMocks()
   })
 
@@ -55,6 +73,7 @@ describe('MarkdownStudioView', () => {
     document.body.innerHTML = ''
     resetBrowserDocumentSessionForTests()
     resetPwaStateForTests()
+    window.CSS = originalCss
     appWindow.desktop = originalDesktop
     window.confirm = originalConfirm
     vi.restoreAllMocks()
@@ -70,7 +89,94 @@ describe('MarkdownStudioView', () => {
     await wrapper.get('button[aria-label="Insert table"]').trigger('click')
     await flushPromises()
 
+    const confirmButton = wrapper.find('button[type="submit"]')
+    expect(confirmButton.exists()).toBe(true)
+    await confirmButton.trigger('click')
+    await flushPromises()
+
     const expectedTable = generateTableTemplate({ columns: 3, rows: 3 })
+    const expectedContent =
+      contentBeforeInsert.slice(0, cursorOffset) +
+      expectedTable +
+      contentBeforeInsert.slice(cursorOffset)
+
+    expect(textarea.value).toBe(expectedContent)
+
+    wrapper.unmount()
+  })
+
+  it('opens the table dimension picker from the Command Palette before inserting', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+    const textarea = wrapper.get('textarea').element as HTMLTextAreaElement
+    const contentBeforeInsert = textarea.value
+    const cursorOffset = 12
+    textarea.setSelectionRange(cursorOffset, cursorOffset)
+
+    dispatchWindowKeydown('k', { metaKey: true })
+    await flushPromises()
+
+    const commandPaletteInput = document.body.querySelector(
+      'input[placeholder="Search commands"]',
+    ) as HTMLInputElement | null
+    expect(commandPaletteInput).not.toBeNull()
+
+    const insertTableCommand = getButtonByText('Insert Table')
+    expect(insertTableCommand).toBeDefined()
+    insertTableCommand?.click()
+    await flushPromises()
+
+    expect(textarea.value).toBe(contentBeforeInsert)
+
+    const columnInput = wrapper.get('input[aria-label="Columns"]').element as HTMLInputElement
+    const rowInput = wrapper.get('input[aria-label="Rows"]').element as HTMLInputElement
+    expect(columnInput.value).toBe('3')
+    expect(rowInput.value).toBe('3')
+
+    await wrapper.get('button[type="submit"]').trigger('click')
+    await flushPromises()
+
+    const expectedTable = generateTableTemplate({ columns: 3, rows: 3 })
+    const expectedContent =
+      contentBeforeInsert.slice(0, cursorOffset) +
+      expectedTable +
+      contentBeforeInsert.slice(cursorOffset)
+
+    expect(textarea.value).toBe(expectedContent)
+
+    wrapper.unmount()
+  })
+
+  it('suppresses global shortcuts while the table dimension picker is open', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+
+    await wrapper.get('button[aria-label="Insert table"]').trigger('click')
+    await flushPromises()
+
+    dispatchWindowKeydown('k', { metaKey: true })
+    await flushPromises()
+
+    expect(document.body.querySelector('input[placeholder="Search commands"]')).toBeNull()
+    expect(wrapper.find('input[aria-label="Columns"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('inserts a non-default table when custom dimensions are confirmed', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+    const textarea = wrapper.get('textarea').element as HTMLTextAreaElement
+    const contentBeforeInsert = textarea.value
+    const cursorOffset = 12
+    textarea.setSelectionRange(cursorOffset, cursorOffset)
+
+    await wrapper.get('button[aria-label="Insert table"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.get('input[aria-label="Columns"]').setValue('4')
+    await wrapper.get('input[aria-label="Rows"]').setValue('2')
+    await wrapper.get('button[type="submit"]').trigger('click')
+    await flushPromises()
+
+    const expectedTable = generateTableTemplate({ columns: 4, rows: 2 })
     const expectedContent =
       contentBeforeInsert.slice(0, cursorOffset) +
       expectedTable +


### PR DESCRIPTION
## Summary

Add a dimension picker that lets users choose row and column counts before inserting a table into the active Markdown Document. The picker defaults to 3×3, clamps values to sensible bounds (1–50), and is reachable from the desktop toolbar, Command Palette, and mobile action sheet. Both web and desktop runtimes share the same insertion path through the workspace controller.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: verified picker opens with 3×3 default, custom dimensions clamp correctly, and GFM table syntax is inserted at the cursor position in both web and desktop runtimes.

## Related Issue

Closes #86

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)