### PR TITLE
fix(desktop): show product name in About menu

### DIFF
--- a/.changeset/friendly-desktop-about.md
+++ b/.changeset/friendly-desktop-about.md
@@ -1,0 +1,7 @@
+---
+'@markdown-studio/desktop': patch
+---
+
+Show the product name in the desktop application menu
+
+- Replace the internal package name in the About menu item with Markdown Studio

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8,6 +8,8 @@ import { buildAppMenu } from './menu/appMenu'
 const preloadPath = fileURLToPath(new URL('../preload/preload.cjs', import.meta.url))
 const rendererHtmlPath = fileURLToPath(new URL('../renderer/index.html', import.meta.url))
 
+app.setName('Markdown Studio')
+
 async function createMainWindow(): Promise<BrowserWindow> {
   const window = new BrowserWindow({
     backgroundColor: '#f7f5f0',


### PR DESCRIPTION
## Summary

Set Electron's runtime application name to the user-facing product name. This changes the macOS application menu item from `About @markdown-studio/desktop` to `About Markdown Studio`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| `About @markdown-studio/desktop` | `About Markdown Studio` |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Confirmed the desktop production build succeeds with `pnpm build:desktop`; verify the macOS application menu displays `About Markdown Studio`.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

N/A

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
