### PR TITLE
feat(preview): make task checkboxes interactive

### DIFF
--- a/.changeset/interactive-preview-tasks.md
+++ b/.changeset/interactive-preview-tasks.md
@@ -1,0 +1,10 @@
+---
+'@markdown-studio/desktop': minor
+'markdown-studio': minor
+---
+
+Make task list checkboxes interactive in the Live Preview
+
+- Toggle task checkboxes directly from the Live Preview
+- Update the matching Markdown source immediately
+- Preserve independent task states and undo support

--- a/packages/app/src/features/markdown/components/PreviewPane.vue
+++ b/packages/app/src/features/markdown/components/PreviewPane.vue
@@ -21,6 +21,7 @@ const desktop = useDesktop()
 const emit = defineEmits<{
   jumpToOffset: [offset: number]
   renderDiagrams: [container: HTMLElement]
+  replaceSourceRange: [start: number, end: number, replacement: string]
 }>()
 
 const previewRef = useTemplateRef<HTMLDivElement>('preview')
@@ -45,6 +46,28 @@ function getSourceElement(entry: MarkdownSourceMapEntry): HTMLElement | null {
     previewRef.value.querySelector<HTMLElement>(`[data-source-id="${entry.id}"]`) ??
     previewRef.value.querySelector<HTMLElement>(`#markdown-source-${entry.id}`)
   )
+}
+
+function handleCheckboxClick(event: MouseEvent): void {
+  const target = event.target
+  if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') return
+
+  const listItem = target.closest<HTMLElement>('[data-checkbox-start][data-checkbox-end]')
+  const checkboxStart = listItem?.dataset.checkboxStart
+  const checkboxEnd = listItem?.dataset.checkboxEnd
+  if (checkboxStart === undefined || checkboxEnd === undefined) return
+
+  emit(
+    'replaceSourceRange',
+    Number.parseInt(checkboxStart, 10),
+    Number.parseInt(checkboxEnd, 10),
+    target.checked ? '[x]' : '[ ]',
+  )
+}
+
+function handleClick(event: MouseEvent): void {
+  handleCheckboxClick(event)
+  handleLinkClick(event)
 }
 
 function handleDoubleClick(event: MouseEvent): void {
@@ -85,6 +108,12 @@ function hydrateSourceAnchors(): void {
     'h1, h2, h3, h4, h5, h6, p, blockquote, li, table, pre, hr, .mermaid-wrap, .html-block',
   )
   if (!candidateElements) return
+
+  for (const checkbox of previewRef.value?.querySelectorAll<HTMLInputElement>(
+    'li[data-checkbox-start][data-checkbox-end] input[type="checkbox"]',
+  ) ?? []) {
+    checkbox.disabled = false
+  }
 
   let candidateIndex = 0
 
@@ -229,7 +258,7 @@ defineExpose({ scrollToSourceOffset })
         :key="renderKey"
         ref="preview"
         class="rendered-md markdown-document markdown-document-theme--app"
-        @click="handleLinkClick"
+        @click="handleClick"
         @dblclick="handleDoubleClick"
         v-html="sanitizedHtml"
       ></div>
@@ -284,6 +313,18 @@ defineExpose({ scrollToSourceOffset })
 
 .rendered-md {
   min-height: 100%;
+}
+
+.rendered-md :deep(input[type='checkbox']) {
+  cursor: pointer;
+  transition:
+    filter 120ms ease,
+    transform 120ms ease;
+}
+
+.rendered-md :deep(input[type='checkbox']:hover) {
+  filter: brightness(1.15);
+  transform: scale(1.08);
 }
 
 @media (max-width: 700px) {

--- a/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
@@ -59,6 +59,49 @@ describe('PreviewPane', () => {
     expect(wrapper.emitted('jumpToOffset')).toEqual([[12]])
   })
 
+  it('requests source replacements when task list checkboxes are clicked', async () => {
+    const wrapper = mount(PreviewPane, {
+      props: {
+        html: [
+          '<ul>',
+          '<li data-checkbox-start="2" data-checkbox-end="5"><input type="checkbox">First</li>',
+          '<li data-checkbox-start="19" data-checkbox-end="22"><input checked type="checkbox">Second</li>',
+          '</ul>',
+        ].join(''),
+        sourceMap: [],
+        theme: 'light',
+        wordCount: 4,
+      },
+    })
+
+    await nextTick()
+    const checkboxes = wrapper.findAll<HTMLInputElement>('input[type="checkbox"]')
+    await checkboxes[0]!.trigger('click')
+    await checkboxes[1]!.trigger('click')
+
+    expect(wrapper.emitted('replaceSourceRange')).toEqual([
+      [2, 5, '[x]'],
+      [19, 22, '[ ]'],
+    ])
+  })
+
+  it('enables rendered task list checkboxes for interaction', async () => {
+    const wrapper = mount(PreviewPane, {
+      props: {
+        html: '<li data-checkbox-start="2" data-checkbox-end="5"><input checked disabled type="checkbox">Task</li>',
+        sourceMap: [],
+        theme: 'light',
+        wordCount: 1,
+      },
+    })
+
+    await nextTick()
+
+    const checkbox = wrapper.get<HTMLInputElement>('input[type="checkbox"]').element
+    expect(checkbox.disabled).toBe(false)
+    expect(checkbox.checked).toBe(true)
+  })
+
   it('preserves source attributes across sanitization and rerenders', async () => {
     const wrapper = mount(PreviewPane, {
       props: {

--- a/packages/app/src/features/markdown/rendered-document/__tests__/renderMarkdownWithSourceMap.spec.ts
+++ b/packages/app/src/features/markdown/rendered-document/__tests__/renderMarkdownWithSourceMap.spec.ts
@@ -47,6 +47,19 @@ describe('renderMarkdownWithSourceMap', () => {
     expect(html).toContain('<table id="markdown-source-block-5" data-source-id=')
   })
 
+  it('tracks task list checkbox source offsets', () => {
+    const content = '- [ ] First task\n- [x] Second task'
+
+    const { html, sourceMap } = renderMarkdownWithSourceMap(content)
+
+    expect(sourceMap).toEqual([
+      expect.objectContaining({ checkboxEnd: 5, checkboxStart: 2, type: 'list_item' }),
+      expect.objectContaining({ checkboxEnd: 22, checkboxStart: 19, type: 'list_item' }),
+    ])
+    expect(html).toContain('data-checkbox-start="2" data-checkbox-end="5"')
+    expect(html).toContain('data-checkbox-start="19" data-checkbox-end="22"')
+  })
+
   it('keeps repeated blocks distinct by offset', () => {
     const content = ['Repeat me', '', 'Repeat me'].join('\n')
 

--- a/packages/app/src/features/markdown/rendered-document/renderMarkdownWithSourceMap.ts
+++ b/packages/app/src/features/markdown/rendered-document/renderMarkdownWithSourceMap.ts
@@ -5,6 +5,8 @@ import { escapeHtml } from '@/utils/escapeHtml'
 import type { MarkdownSourceMapEntry } from '../types'
 
 type AnnotatedToken = {
+  checkboxEnd?: number
+  checkboxStart?: number
   sourceEnd?: number
   sourceId?: string
   sourceStart?: number
@@ -63,11 +65,25 @@ function annotateTokens(
         itemCursor = itemEnd
 
         const annotatedItem = item as AnnotatedToken
+        const checkboxMatch = item.raw.match(/^\s*(?:[-+*]|\d+[.)])\s+(\[[ xX]\])/)
+        const checkboxStart = checkboxMatch
+          ? itemStart + checkboxMatch[0].lastIndexOf(checkboxMatch[1]!)
+          : undefined
+        const checkboxEnd = checkboxStart === undefined ? undefined : checkboxStart + 3
         const id = `block-${sourceMap.length}`
+        annotatedItem.checkboxEnd = checkboxEnd
+        annotatedItem.checkboxStart = checkboxStart
         annotatedItem.sourceId = id
         annotatedItem.sourceStart = itemStart
         annotatedItem.sourceEnd = itemEnd
-        sourceMap.push({ end: itemEnd, id, start: itemStart, type: item.type })
+        sourceMap.push({
+          checkboxEnd,
+          checkboxStart,
+          end: itemEnd,
+          id,
+          start: itemStart,
+          type: item.type,
+        })
       }
     }
   }
@@ -84,7 +100,12 @@ function buildAttrs(token: AnnotatedToken): string {
     return ''
   }
 
-  return ` id="markdown-source-${token.sourceId}" data-source-id="${token.sourceId}" data-source-start="${token.sourceStart}" data-source-end="${token.sourceEnd}"`
+  const checkboxAttrs =
+    token.checkboxStart === undefined || token.checkboxEnd === undefined
+      ? ''
+      : ` data-checkbox-start="${token.checkboxStart}" data-checkbox-end="${token.checkboxEnd}"`
+
+  return ` id="markdown-source-${token.sourceId}" data-source-id="${token.sourceId}" data-source-start="${token.sourceStart}" data-source-end="${token.sourceEnd}"${checkboxAttrs}`
 }
 
 function createRenderer() {

--- a/packages/app/src/features/markdown/types/common.ts
+++ b/packages/app/src/features/markdown/types/common.ts
@@ -13,6 +13,8 @@ export interface Example {
 }
 
 export interface MarkdownSourceMapEntry {
+  checkboxEnd?: number
+  checkboxStart?: number
   end: number
   id: string
   start: number

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -216,6 +216,10 @@ function handleInstall(): void {
   })
 }
 
+function handleReplaceSourceRange(start: number, end: number, replacement: string): void {
+  void editorPaneRef.value?.replaceRange(start, end, replacement)
+}
+
 function handleStartNewDocument(): void {
   void workspace.document.startNew().catch((error: unknown) => {
     console.error('Failed to start new document:', error)
@@ -305,6 +309,7 @@ function handleTableInsertionConfirm(): void {
         :word-count="stats.words"
         @jump-to-offset="workspace.preview.jumpToOffset"
         @render-diagrams="workspace.preview.renderDiagrams"
+        @replace-source-range="handleReplaceSourceRange"
       />
     </main>
 

--- a/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
+++ b/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
@@ -79,6 +79,25 @@ describe('MarkdownStudioView', () => {
     vi.restoreAllMocks()
   })
 
+  it('updates the matching Markdown task when its Live Preview checkbox is clicked', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+    const textarea = wrapper.get('textarea')
+    await textarea.setValue('- [ ] First task\n- [ ] Second task')
+    await flushPromises()
+
+    const checkboxes = wrapper.findAll<HTMLInputElement>('.rendered-md input[type="checkbox"]')
+    expect(checkboxes).toHaveLength(2)
+
+    await checkboxes[1]!.trigger('click')
+    await flushPromises()
+
+    expect((textarea.element as HTMLTextAreaElement).value).toBe(
+      '- [ ] First task\n- [x] Second task',
+    )
+
+    wrapper.unmount()
+  })
+
   it('inserts a default table when the toolbar insert table button is clicked', async () => {
     const { wrapper } = await mountMarkdownStudioView()
     const textarea = wrapper.get('textarea').element as HTMLTextAreaElement


### PR DESCRIPTION
## Summary

Make task list checkboxes interactive in the Live Preview across web and desktop Runtimes. Checkbox clicks update the matching Markdown source immediately through the existing undoable editor replacement path.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| Not captured | Not captured |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [ ] Manual testing notes: Not performed; renderer, component, and Editor Workspace integration tests cover checkbox toggling.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

Closes #83

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
