### PR TITLE
fix(release): handle missing publish tags

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          remote_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha' 2>/dev/null || true)"
+          remote_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha' 2>/dev/null)" || remote_sha=""
 
           if [[ -n "$remote_sha" && "$remote_sha" != "$RELEASE_SHA" ]]; then
             echo "Tag $RELEASE_TAG already exists on a different commit: $remote_sha" >&2

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          remote_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha' 2>/dev/null || true)"
+          remote_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha' 2>/dev/null)" || remote_sha=""
 
           if [[ -n "$remote_sha" && "$remote_sha" != "$RELEASE_SHA" ]]; then
             echo "Tag $RELEASE_TAG already exists on a different commit: $remote_sha" >&2


### PR DESCRIPTION
## Summary

Fix release tag lookup in the npm and desktop publishing workflows. A missing GitHub tag returns a 404 JSON response on stdout; the workflows previously captured that response as a commit SHA and incorrectly reported that the tag existed on another commit.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [x] Workflow
- [ ] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [ ] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Confirmed a missing tag resolves to an empty value and an existing tag resolves to its commit SHA. Ran `pnpm format`, `pnpm lint`, and `pnpm type-check` successfully.

## Related Issue

Failed GitHub Actions job: https://github.com/theoklitosBam7/markdown-studio/actions/runs/22038384984/job/86574059147

## Pre-flight Checklist

- [ ] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
