### PR TITLE
feat(editor): add document outline navigation

### DIFF
--- a/.changeset/calm-owls-outline.md
+++ b/.changeset/calm-owls-outline.md
@@ -1,0 +1,10 @@
+---
+"@markdown-studio/desktop": minor
+"markdown-studio": minor
+---
+
+Add a collapsible document outline for navigating Markdown headings
+
+- Show H1–H6 headings with hierarchical indentation and active-position highlighting
+- Navigate the editor cursor when an outline heading is selected
+- Provide animated desktop and full-width mobile outline layouts

--- a/packages/app/src/components/base/MobileToolbarActions.vue
+++ b/packages/app/src/components/base/MobileToolbarActions.vue
@@ -17,6 +17,7 @@ interface Props {
   canOpenDocuments?: boolean
   canSaveDocuments?: boolean
   isCopied: boolean
+  isOutlineOpen?: boolean
   pdfExportUnavailableReason?: string
   theme: Theme
   viewMode: ViewMode
@@ -28,6 +29,7 @@ const props = withDefaults(defineProps<Props>(), {
   canInstall: false,
   canOpenDocuments: false,
   canSaveDocuments: false,
+  isOutlineOpen: false,
   pdfExportUnavailableReason: '',
 })
 
@@ -42,6 +44,7 @@ const emit = defineEmits<{
   openExamples: []
   openShortcuts: []
   saveDocument: []
+  toggleOutline: []
   'update:theme': [payload: { origin: { x: number; y: number }; theme: Theme }]
   'update:viewMode': [mode: ViewMode]
 }>()
@@ -182,6 +185,24 @@ function openActionSheet(): void {
     </div>
 
     <div class="mobile-toolbar-actions__row mobile-toolbar-actions__row--secondary">
+      <ToolbarButton
+        icon-only
+        :aria-label="props.isOutlineOpen ? 'Hide document outline' : 'Show document outline'"
+        :aria-pressed="props.isOutlineOpen"
+        @click="emit('toggleOutline')"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          aria-hidden="true"
+        >
+          <rect x="2" y="2.5" width="12" height="11" rx="1.5" />
+          <path d="M6 2.5v11" />
+          <path d="M3.5 5h1M3.5 7.5h1M3.5 10h1" />
+        </svg>
+      </ToolbarButton>
       <ViewToggle
         compact
         :available-modes="availableModes"

--- a/packages/app/src/features/markdown/components/OutlineSidebar.vue
+++ b/packages/app/src/features/markdown/components/OutlineSidebar.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import type { MarkdownOutlineHeading } from '../types'
+
+interface Props {
+  activeHeadingId?: null | string
+  headings: MarkdownOutlineHeading[]
+}
+
+withDefaults(defineProps<Props>(), {
+  activeHeadingId: null,
+})
+
+const emit = defineEmits<{
+  navigate: [offset: number]
+}>()
+
+function headingStyle(depth: number): Record<string, string> {
+  return { '--heading-depth': String(Math.max(0, depth - 1)) }
+}
+</script>
+
+<template>
+  <aside class="outline-sidebar">
+    <div class="outline-sidebar__header">Outline</div>
+    <nav aria-label="Document outline" class="outline-sidebar__navigation">
+      <p v-if="headings.length === 0" class="outline-sidebar__empty">No headings</p>
+      <button
+        v-for="heading in headings"
+        :key="heading.id"
+        :aria-current="heading.id === activeHeadingId ? 'location' : undefined"
+        class="outline-sidebar__heading"
+        :class="{ 'outline-sidebar__heading--active': heading.id === activeHeadingId }"
+        :style="headingStyle(heading.depth)"
+        type="button"
+        @click="emit('navigate', heading.start)"
+      >
+        {{ heading.text }}
+      </button>
+    </nav>
+  </aside>
+</template>
+
+<style scoped>
+.outline-sidebar {
+  width: 260px;
+  min-width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+}
+
+.outline-sidebar__header {
+  height: 42px;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.outline-sidebar__navigation {
+  height: calc(100% - 43px);
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.outline-sidebar__heading {
+  width: 100%;
+  display: block;
+  overflow: hidden;
+  padding: 7px 8px 7px calc(8px + var(--heading-depth) * 14px);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.outline-sidebar__heading:hover {
+  background: var(--panel);
+  color: var(--text);
+}
+
+.outline-sidebar__heading--active {
+  background: var(--accent-light);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.outline-sidebar__heading:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.outline-sidebar__empty {
+  margin: 0;
+  padding: 12px 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+@media (max-width: 700px) {
+  .outline-sidebar {
+    width: 100%;
+    border-right: 0;
+  }
+}
+</style>

--- a/packages/app/src/features/markdown/components/Toolbar.vue
+++ b/packages/app/src/features/markdown/components/Toolbar.vue
@@ -17,6 +17,7 @@ interface Props {
   canSaveDocuments?: boolean
   isCopied: boolean
   isMobile?: boolean
+  isOutlineOpen?: boolean
   pdfExportUnavailableReason?: string
   theme: Theme
   viewMode: ViewMode
@@ -29,6 +30,7 @@ const props = withDefaults(defineProps<Props>(), {
   canOpenDocuments: false,
   canSaveDocuments: false,
   isMobile: false,
+  isOutlineOpen: false,
   pdfExportUnavailableReason: '',
 })
 
@@ -43,6 +45,7 @@ const emit = defineEmits<{
   openExamples: []
   openShortcuts: []
   saveDocument: []
+  toggleOutline: []
   'update:theme': [payload: ThemeChangeRequest]
   'update:viewMode': [mode: ViewMode]
 }>()
@@ -77,6 +80,10 @@ function openShortcuts(): void {
 
 function saveDocument(): void {
   emit('saveDocument')
+}
+
+function toggleOutline(): void {
+  emit('toggleOutline')
 }
 
 const exportMenuRef = useTemplateRef<HTMLDetailsElement>('exportMenu')
@@ -144,6 +151,7 @@ onUnmounted(() => {
       :can-open-documents="props.canOpenDocuments"
       :can-save-documents="props.canSaveDocuments"
       :is-copied="props.isCopied"
+      :is-outline-open="props.isOutlineOpen"
       :pdf-export-unavailable-reason="props.pdfExportUnavailableReason"
       :theme="props.theme"
       :view-mode="props.viewMode"
@@ -157,6 +165,7 @@ onUnmounted(() => {
       @open-examples="openExamples"
       @open-shortcuts="openShortcuts"
       @save-document="saveDocument"
+      @toggle-outline="toggleOutline"
       @update:theme="handleThemeChange"
       @update:view-mode="handleViewModeChange"
     />
@@ -285,6 +294,25 @@ onUnmounted(() => {
         </a>
 
         <div class="toolbar__desktop-controls">
+          <ToolbarButton
+            icon-only
+            :aria-label="props.isOutlineOpen ? 'Hide document outline' : 'Show document outline'"
+            :aria-pressed="props.isOutlineOpen"
+            :title="props.isOutlineOpen ? 'Hide document outline' : 'Show document outline'"
+            @click="toggleOutline"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              aria-hidden="true"
+            >
+              <rect x="2" y="2.5" width="12" height="11" rx="1.5" />
+              <path d="M6 2.5v11" />
+              <path d="M3.5 5h1M3.5 7.5h1M3.5 10h1" />
+            </svg>
+          </ToolbarButton>
           <ViewToggle
             :available-modes="props.availableModes"
             :model-value="props.viewMode"

--- a/packages/app/src/features/markdown/components/__tests__/OutlineSidebar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/OutlineSidebar.spec.ts
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import OutlineSidebar from '../OutlineSidebar.vue'
+
+describe('OutlineSidebar', () => {
+  it('shows heading hierarchy and emits the selected source offset', async () => {
+    const wrapper = mount(OutlineSidebar, {
+      props: {
+        activeHeadingId: 'block-1',
+        headings: [
+          { depth: 1, id: 'block-0', start: 0, text: 'Title' },
+          { depth: 3, id: 'block-1', start: 18, text: 'Details' },
+        ],
+      },
+    })
+
+    const links = wrapper.findAll('.outline-sidebar__heading')
+    expect(links.map((link) => link.text())).toEqual(['Title', 'Details'])
+    expect(links[0]?.attributes('style')).toContain('--heading-depth: 0')
+    expect(links[1]?.attributes('style')).toContain('--heading-depth: 2')
+    expect(links[1]?.attributes('aria-current')).toBe('location')
+
+    await links[1]?.trigger('click')
+
+    expect(wrapper.emitted('navigate')).toEqual([[18]])
+  })
+})

--- a/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/Toolbar.spec.ts
@@ -77,6 +77,18 @@ describe('Toolbar', () => {
     expect(wrapper.emitted('insertTable')).toHaveLength(1)
   })
 
+  it('renders an accessible icon control for toggling the document outline', async () => {
+    const wrapper = mountToolbar({ isOutlineOpen: true })
+
+    const outlineButton = wrapper.get('button[aria-label="Hide document outline"]')
+    expect(outlineButton.attributes('aria-pressed')).toBe('true')
+    expect(outlineButton.find('svg[aria-hidden="true"]').exists()).toBe(true)
+
+    await outlineButton.trigger('click')
+
+    expect(wrapper.emitted('toggleOutline')).toHaveLength(1)
+  })
+
   it('renders keyboard shortcuts as an accessible icon control', async () => {
     const wrapper = mountToolbar()
 
@@ -116,6 +128,22 @@ describe('Toolbar', () => {
     expect(
       wrapper.find('.mobile-toolbar-actions button[aria-label="Switch to dark mode"]').exists(),
     ).toBe(true)
+  })
+
+  it('keeps the outline toggle available in the compact mobile toolbar', async () => {
+    const wrapper = mountToolbar({
+      availableModes: ['editor', 'preview'],
+      isMobile: true,
+      isOutlineOpen: false,
+      viewMode: 'editor',
+    })
+
+    const outlineButton = wrapper.get('button[aria-label="Show document outline"]')
+    expect(outlineButton.classes()).toContain('icon-only')
+
+    await outlineButton.trigger('click')
+
+    expect(wrapper.emitted('toggleOutline')).toHaveLength(1)
   })
 
   it('opens action sheet when hamburger menu is clicked', async () => {

--- a/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useEditorWorkspaceController.spec.ts
@@ -151,6 +151,54 @@ describe('useEditorWorkspaceController', () => {
     wrapper.unmount()
   })
 
+  it('tracks outline visibility and the active heading from editor scrolling', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const content = '# Introduction\nBody\n## Details\nMore'
+
+    workspace.editor.updateContent(content)
+    workspace.outline.toggle()
+    workspace.editor.syncPreviewToEditorPosition({
+      clientHeight: 200,
+      contentLength: content.length,
+      lineHeight: 20,
+      scrollHeight: 400,
+      scrollTop: 40,
+    })
+
+    expect(workspace.state.isOutlineOpen.value).toBe(true)
+    expect(
+      workspace.state.outlineHeadings.value.map(({ depth, text }) => ({ depth, text })),
+    ).toEqual([
+      { depth: 1, text: 'Introduction' },
+      { depth: 2, text: 'Details' },
+    ])
+    expect(workspace.state.activeOutlineHeadingId.value).toBe(
+      workspace.state.outlineHeadings.value[1]?.id,
+    )
+
+    wrapper.unmount()
+  })
+
+  it('navigates from the mobile outline without changing the Workspace View Mode', async () => {
+    const { workspace, wrapper } = await mountWorkspace()
+    const editor = createEditorAdapter()
+    const preview = createPreviewAdapter()
+    workspace.attach.editor(editor)
+    workspace.attach.preview(preview)
+    workspace.system.handleViewportResize(640)
+    workspace.editor.setViewMode('preview')
+    workspace.outline.toggle()
+
+    await workspace.outline.navigate(18)
+
+    expect(editor.focusAtOffset).toHaveBeenCalledWith(18)
+    expect(preview.scrollToSourceOffset).toHaveBeenCalledWith(18)
+    expect(workspace.state.viewMode.value).toBe('preview')
+    expect(workspace.state.isOutlineOpen.value).toBe(false)
+
+    wrapper.unmount()
+  })
+
   it('jumps from preview to editor offsets only while split view is active', async () => {
     const { workspace, wrapper } = await mountWorkspace()
     const editor = createEditorAdapter()

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -16,6 +16,7 @@ import type {
   ThemeChangeRequest,
 } from '../types/workspace'
 
+import { extractHeadings } from '../rendered-document'
 import { EXAMPLES } from './examples'
 import { useDesktopDraftPersistence } from './useDesktopDraftPersistence'
 import { useDocumentExport } from './useDocumentExport'
@@ -37,8 +38,10 @@ const MOBILE_BREAKPOINT = 700
 export function useEditorWorkspaceController(): EditorWorkspaceController {
   const editorPane = shallowRef<EditorPaneAdapter | null>(null)
   const previewPane = shallowRef<null | PreviewPaneAdapter>(null)
+  const activeEditorOffset = shallowRef(0)
   const isExamplesModalOpen = shallowRef(false)
   const isMobile = shallowRef(false)
+  const isOutlineOpen = shallowRef(false)
   const isStarted = shallowRef(false)
 
   const {
@@ -170,6 +173,17 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     'view-preview': viewMode.value === 'preview',
     'view-split': viewMode.value === 'split',
   }))
+  const outlineHeadings = computed(() => extractHeadings(sourceMap.value))
+  const activeOutlineHeadingId = computed(() => {
+    let activeHeadingId: null | string = null
+
+    for (const heading of outlineHeadings.value) {
+      if (heading.start > activeEditorOffset.value) break
+      activeHeadingId = heading.id
+    }
+
+    return activeHeadingId
+  })
   const findState = computed(() => ({
     activeMatchIndex: activeMatchIndex.value,
     isOpen: isFindReplaceOpen.value,
@@ -288,8 +302,6 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
   }
 
   function syncPreviewToEditorPosition(scrollState?: EditorScrollPayload | null): void {
-    if (isMobile.value || viewMode.value !== 'split') return
-
     const effectiveScrollState = scrollState ?? editorPane.value?.getScrollState()
     if (!effectiveScrollState) return
 
@@ -298,6 +310,10 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       Math.floor(effectiveScrollState.scrollTop / effectiveScrollState.lineHeight),
     )
     const sourceOffset = getOffsetForLine(content.value, topLine)
+    activeEditorOffset.value = sourceOffset
+
+    if (isMobile.value || viewMode.value !== 'split') return
+
     previewPane.value?.scrollToSourceOffset(sourceOffset)
   }
 
@@ -490,6 +506,25 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
     syncViewport(width)
   }
 
+  async function navigateFromOutline(offset: number): Promise<void> {
+    activeEditorOffset.value = offset
+
+    if (isMobile.value) {
+      isOutlineOpen.value = false
+      await nextTick()
+    }
+
+    if (viewMode.value !== 'editor') {
+      previewPane.value?.scrollToSourceOffset(offset)
+    }
+
+    await editorPane.value?.focusAtOffset(offset)
+  }
+
+  function toggleOutline(): void {
+    isOutlineOpen.value = !isOutlineOpen.value
+  }
+
   function closeFindPanel(): void {
     closeFindReplace()
     editorPane.value?.focus()
@@ -583,6 +618,10 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       setReplaceText,
       state: findState,
     },
+    outline: {
+      navigate: navigateFromOutline,
+      toggle: toggleOutline,
+    },
     preview: {
       async jumpToOffset(offset: number): Promise<void> {
         await jumpToOffset(offset)
@@ -592,6 +631,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       },
     },
     state: {
+      activeOutlineHeadingId,
       availableModes,
       bannerStatus,
       bodyClasses,
@@ -608,7 +648,9 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       isExamplesModalOpen,
       isHomebrewInstall: isHomebrewInstallRef,
       isMobile,
+      isOutlineOpen,
       isTableDimensionPickerOpen: tableInsertion.isPickerOpen,
+      outlineHeadings,
       pdfExportUnavailableReason,
       pwaBannerStatus,
       renderedHtml,

--- a/packages/app/src/features/markdown/index.ts
+++ b/packages/app/src/features/markdown/index.ts
@@ -3,7 +3,7 @@ export { useDocumentExport } from './composables/useDocumentExport'
 // Composables
 export { useEditorWorkspaceController } from './composables/useEditorWorkspaceController'
 export { useMarkdownEditor } from './composables/useMarkdownEditor'
-export { renderMarkdownWithSourceMap } from './rendered-document'
+export { extractHeadings, renderMarkdownWithSourceMap } from './rendered-document'
 
 export {
   buildExportHtml,
@@ -22,6 +22,7 @@ export type {
   EditorWorkspaceFindApi,
   EditorWorkspaceState,
   Example,
+  MarkdownOutlineHeading,
   MarkdownSourceMapEntry,
   PreviewPaneAdapter,
   Theme,

--- a/packages/app/src/features/markdown/rendered-document/__tests__/extractHeadings.spec.ts
+++ b/packages/app/src/features/markdown/rendered-document/__tests__/extractHeadings.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractHeadings } from '../extractHeadings'
+
+describe('extractHeadings', () => {
+  it('returns ordered outline headings from Source Navigation entries', () => {
+    const headings = extractHeadings([
+      { depth: 1, end: 8, id: 'block-0', start: 0, text: 'Title', type: 'heading' },
+      { end: 20, id: 'block-1', start: 9, type: 'paragraph' },
+      { depth: 3, end: 34, id: 'block-2', start: 21, text: 'Details', type: 'heading' },
+    ])
+
+    expect(headings).toEqual([
+      { depth: 1, id: 'block-0', start: 0, text: 'Title' },
+      { depth: 3, id: 'block-2', start: 21, text: 'Details' },
+    ])
+  })
+})

--- a/packages/app/src/features/markdown/rendered-document/__tests__/renderMarkdownWithSourceMap.spec.ts
+++ b/packages/app/src/features/markdown/rendered-document/__tests__/renderMarkdownWithSourceMap.spec.ts
@@ -47,6 +47,34 @@ describe('renderMarkdownWithSourceMap', () => {
     expect(html).toContain('<table id="markdown-source-block-5" data-source-id=')
   })
 
+  it('exposes heading depth and text for the document outline', () => {
+    const content = [
+      '# Document title',
+      '## Section',
+      '### Subsection',
+      '#### Detail',
+      '##### Note',
+      '###### Fine print',
+      '',
+      'Paragraph text',
+    ].join('\n')
+
+    const { sourceMap } = renderMarkdownWithSourceMap(content)
+
+    expect(
+      sourceMap
+        .filter((entry) => entry.type === 'heading')
+        .map(({ depth, start, text }) => ({ depth, start, text })),
+    ).toEqual([
+      { depth: 1, start: 0, text: 'Document title' },
+      { depth: 2, start: content.indexOf('## Section'), text: 'Section' },
+      { depth: 3, start: content.indexOf('### Subsection'), text: 'Subsection' },
+      { depth: 4, start: content.indexOf('#### Detail'), text: 'Detail' },
+      { depth: 5, start: content.indexOf('##### Note'), text: 'Note' },
+      { depth: 6, start: content.indexOf('###### Fine print'), text: 'Fine print' },
+    ])
+  })
+
   it('tracks task list checkbox source offsets', () => {
     const content = '- [ ] First task\n- [x] Second task'
 

--- a/packages/app/src/features/markdown/rendered-document/extractHeadings.ts
+++ b/packages/app/src/features/markdown/rendered-document/extractHeadings.ts
@@ -1,0 +1,18 @@
+import type { MarkdownOutlineHeading, MarkdownSourceMapEntry } from '../types'
+
+export function extractHeadings(sourceMap: MarkdownSourceMapEntry[]): MarkdownOutlineHeading[] {
+  return sourceMap.flatMap((entry) => {
+    if (entry.type !== 'heading' || entry.depth === undefined || entry.text === undefined) {
+      return []
+    }
+
+    return [
+      {
+        depth: entry.depth,
+        id: entry.id,
+        start: entry.start,
+        text: entry.text,
+      },
+    ]
+  })
+}

--- a/packages/app/src/features/markdown/rendered-document/index.ts
+++ b/packages/app/src/features/markdown/rendered-document/index.ts
@@ -8,6 +8,7 @@ import type { MarkdownSourceMapEntry } from '../types'
 import markdownDocumentCss from '../styles/markdown-document.css?raw'
 import { renderMarkdownWithSourceMap } from './renderMarkdownWithSourceMap'
 
+export { extractHeadings } from './extractHeadings'
 export { renderMarkdownWithSourceMap }
 
 export interface RenderedMarkdownDiagnostic {

--- a/packages/app/src/features/markdown/rendered-document/renderMarkdownWithSourceMap.ts
+++ b/packages/app/src/features/markdown/rendered-document/renderMarkdownWithSourceMap.ts
@@ -54,7 +54,14 @@ function annotateTokens(
       annotatedToken.sourceId = id
       annotatedToken.sourceStart = start
       annotatedToken.sourceEnd = end
-      sourceMap.push({ end, id, start, type: token.type })
+      sourceMap.push({
+        depth: token.type === 'heading' ? token.depth : undefined,
+        end,
+        id,
+        start,
+        text: token.type === 'heading' ? token.text : undefined,
+        type: token.type,
+      })
     }
 
     if (token.type === 'list') {

--- a/packages/app/src/features/markdown/types/common.ts
+++ b/packages/app/src/features/markdown/types/common.ts
@@ -12,12 +12,21 @@ export interface Example {
   title: string
 }
 
+export interface MarkdownOutlineHeading {
+  depth: number
+  id: string
+  start: number
+  text: string
+}
+
 export interface MarkdownSourceMapEntry {
   checkboxEnd?: number
   checkboxStart?: number
+  depth?: number
   end: number
   id: string
   start: number
+  text?: string
   type: string
 }
 

--- a/packages/app/src/features/markdown/types/index.ts
+++ b/packages/app/src/features/markdown/types/index.ts
@@ -1,4 +1,11 @@
-export type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './common'
+export type {
+  EditorStats,
+  Example,
+  MarkdownOutlineHeading,
+  MarkdownSourceMapEntry,
+  Theme,
+  ViewMode,
+} from './common'
 
 export type { Shortcut, ShortcutBinding, ShortcutId } from './shortcuts'
 

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -2,7 +2,14 @@ import type { AppCommand } from '@markdown-studio/desktop-contract/types'
 import type { ComputedRef, Ref, ShallowRef } from 'vue'
 
 import type { FindMatch } from '../composables/useFindReplace'
-import type { EditorStats, Example, MarkdownSourceMapEntry, Theme, ViewMode } from './common'
+import type {
+  EditorStats,
+  Example,
+  MarkdownOutlineHeading,
+  MarkdownSourceMapEntry,
+  Theme,
+  ViewMode,
+} from './common'
 
 /**
  * Imperative capabilities exposed by the editor pane.
@@ -70,6 +77,10 @@ export interface EditorWorkspaceController {
     pdf(): Promise<void>
   }
   find: EditorWorkspaceFindApi
+  outline: {
+    navigate(offset: number): Promise<void>
+    toggle(): void
+  }
   preview: {
     jumpToOffset(offset: number): Promise<void>
     renderDiagrams(container: HTMLElement): Promise<void>
@@ -123,6 +134,7 @@ export interface EditorWorkspaceFindState {
  * rather than the primary orchestration owner.
  */
 export interface EditorWorkspaceState {
+  activeOutlineHeadingId: ComputedRef<null | string>
   availableModes: ComputedRef<ViewMode[]>
   bannerStatus: Readonly<Ref<'up-to-date' | 'update-available'>>
   bodyClasses: ComputedRef<Record<string, boolean>>
@@ -139,7 +151,9 @@ export interface EditorWorkspaceState {
   isExamplesModalOpen: ShallowRef<boolean>
   isHomebrewInstall: Readonly<Ref<boolean>>
   isMobile: ShallowRef<boolean>
+  isOutlineOpen: ShallowRef<boolean>
   isTableDimensionPickerOpen: Readonly<Ref<boolean>>
+  outlineHeadings: ComputedRef<MarkdownOutlineHeading[]>
   pdfExportUnavailableReason: Readonly<Ref<string>>
   pwaBannerStatus: Readonly<Ref<'offline-ready' | 'update-available'>>
   renderedHtml: Readonly<Ref<string>>

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -6,6 +6,7 @@ import type { EditorScrollPayload, ShortcutBinding } from '@/features/markdown/t
 import CommandPalette from '@/features/markdown/components/CommandPalette.vue'
 import EditorPane from '@/features/markdown/components/EditorPane.vue'
 import ExamplesModal from '@/features/markdown/components/ExamplesModal.vue'
+import OutlineSidebar from '@/features/markdown/components/OutlineSidebar.vue'
 import PreviewPane from '@/features/markdown/components/PreviewPane.vue'
 import PwaBanner from '@/features/markdown/components/PwaBanner.vue'
 import ShortcutsHelp from '@/features/markdown/components/ShortcutsHelp.vue'
@@ -82,6 +83,7 @@ const { shortcuts } = useShortcuts({
 })
 
 const {
+  activeOutlineHeadingId,
   availableModes,
   bannerStatus,
   bodyClasses,
@@ -97,6 +99,8 @@ const {
   isExamplesModalOpen,
   isHomebrewInstall,
   isMobile,
+  isOutlineOpen,
+  outlineHeadings,
   pdfExportUnavailableReason,
   pwaBannerStatus,
   renderedHtml,
@@ -250,6 +254,7 @@ function handleTableInsertionConfirm(): void {
       :can-install="canInstall"
       :can-save-documents="canSaveDocuments"
       :is-mobile="isMobile"
+      :is-outline-open="isOutlineOpen"
       :view-mode="viewMode"
       :pdf-export-unavailable-reason="pdfExportUnavailableReason"
       :theme="theme"
@@ -266,6 +271,7 @@ function handleTableInsertionConfirm(): void {
       @export-html="handleExportHtml"
       @export-pdf="handleExportPdf"
       @save-document="workspace.document.save"
+      @toggle-outline="workspace.outline.toggle"
     />
 
     <Transition name="banner-slide">
@@ -290,7 +296,18 @@ function handleTableInsertionConfirm(): void {
       />
     </Transition>
 
-    <main class="main-content">
+    <main
+      class="main-content"
+      :class="{ 'main-content--mobile-outline': isMobile && isOutlineOpen }"
+    >
+      <Transition name="outline-slide">
+        <OutlineSidebar
+          v-if="isOutlineOpen"
+          :active-heading-id="activeOutlineHeadingId"
+          :headings="outlineHeadings"
+          @navigate="workspace.outline.navigate"
+        />
+      </Transition>
       <!-- workspace.find.state is a ComputedRef, so we pass its current snapshot via .value -->
       <EditorPane
         ref="editorPane"
@@ -402,9 +419,45 @@ function handleTableInsertionConfirm(): void {
   border-right: none;
 }
 
+.outline-slide-enter-active,
+.outline-slide-leave-active {
+  transition:
+    max-width 0.22s ease,
+    opacity 0.18s ease,
+    transform 0.22s ease;
+}
+
+.outline-slide-enter-from,
+.outline-slide-leave-to {
+  max-width: 0;
+  opacity: 0;
+  transform: translateX(-16px);
+}
+
+.outline-slide-enter-to,
+.outline-slide-leave-from {
+  max-width: 260px;
+  opacity: 1;
+  transform: translateX(0);
+}
+
 @media (max-width: 700px) {
   .main-content {
     flex-direction: column;
+  }
+
+  .main-content--mobile-outline :deep(.editor-pane),
+  .main-content--mobile-outline :deep(.preview-pane) {
+    display: none;
+  }
+
+  .main-content--mobile-outline :deep(.outline-sidebar) {
+    height: 100%;
+  }
+
+  .outline-slide-enter-to,
+  .outline-slide-leave-from {
+    max-width: 100%;
   }
 
   .markdown-studio :deep(.editor-pane),

--- a/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
+++ b/packages/app/src/views/__tests__/MarkdownStudioView.spec.ts
@@ -98,6 +98,32 @@ describe('MarkdownStudioView', () => {
     wrapper.unmount()
   })
 
+  it('opens the document outline and navigates the editor to a selected heading', async () => {
+    const { wrapper } = await mountMarkdownStudioView()
+    const textarea = wrapper.get('textarea')
+    const content = '# Introduction\nBody\n## Details\nMore'
+    await textarea.setValue(content)
+    await flushPromises()
+
+    await wrapper.get('button[aria-label="Show document outline"]').trigger('click')
+    await flushPromises()
+
+    const outline = wrapper.get('nav[aria-label="Document outline"]')
+    expect(outline.findAll('button').map((button) => button.text())).toEqual([
+      'Introduction',
+      'Details',
+    ])
+
+    await outline.findAll('button')[1]?.trigger('click')
+    await flushPromises()
+
+    expect((textarea.element as HTMLTextAreaElement).selectionStart).toBe(
+      content.indexOf('## Details'),
+    )
+
+    wrapper.unmount()
+  })
+
   it('inserts a default table when the toolbar insert table button is clicked', async () => {
     const { wrapper } = await mountMarkdownStudioView()
     const textarea = wrapper.get('textarea').element as HTMLTextAreaElement


### PR DESCRIPTION
## Summary

Adds a collapsible document outline that presents H1–H6 structure and highlights the active heading while editing. Outline selections keep the editor and Live Preview aligned across desktop and web runtimes, with an animated desktop panel and full-width mobile layout.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [ ] Test

## Screenshots

| Before | After |
| ------ | ----- |
| N/A | N/A |

## Test Procedure

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified outline toggling, heading navigation, active-heading tracking, Preview synchronization, and responsive mobile behavior.

## Related Issue

Closes #84

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
