### PR TITLE
feat(desktop): add image drag and drop

### DIFF
--- a/.changeset/tidy-images-drop.md
+++ b/.changeset/tidy-images-drop.md
@@ -1,0 +1,10 @@
+---
+"@markdown-studio/desktop": minor
+---
+
+Add image drag and drop to saved Markdown Documents
+
+- Save dropped images in a managed `.markdown-studio/assets` folder
+- Insert relative Markdown image links at the editor cursor
+- Display managed images in Live Preview and desktop PDF exports
+- Highlight the Editor Workspace while a supported image is dragged over it

--- a/apps/desktop/electron/asset-protocol.spec.ts
+++ b/apps/desktop/electron/asset-protocol.spec.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { handleAssetRequest } from './asset-protocol'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  )
+})
+
+describe('desktop asset protocol', () => {
+  it('serves an image from the Markdown Document assets folder', async () => {
+    const documentDirectory = await mkdtemp(join(tmpdir(), 'markdown-studio-assets-'))
+    temporaryDirectories.push(documentDirectory)
+    const assetsDirectory = join(documentDirectory, '.markdown-studio', 'assets')
+    await mkdir(assetsDirectory, { recursive: true })
+    await writeFile(join(assetsDirectory, 'diagram.png'), new Uint8Array([137, 80, 78, 71]))
+    const url = new URL('markdown-studio-asset://local/')
+    url.searchParams.set('documentPath', join(documentDirectory, 'notes.md'))
+    url.searchParams.set('relativePath', './.markdown-studio/assets/diagram.png')
+
+    const response = await handleAssetRequest(new Request(url))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([137, 80, 78, 71]))
+  })
+})

--- a/apps/desktop/electron/asset-protocol.ts
+++ b/apps/desktop/electron/asset-protocol.ts
@@ -1,0 +1,55 @@
+import { readFile, realpath } from 'node:fs/promises'
+import { dirname, extname, isAbsolute, relative, resolve } from 'node:path'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+}
+
+export async function handleAssetRequest(request: Request): Promise<Response> {
+  try {
+    const url = new URL(request.url)
+    const documentPath = url.searchParams.get('documentPath')
+    const relativePath = url.searchParams.get('relativePath')
+
+    if (
+      url.protocol !== 'markdown-studio-asset:' ||
+      !documentPath ||
+      !relativePath?.startsWith('./.markdown-studio/assets/')
+    ) {
+      return new Response('Invalid asset request.', { status: 400 })
+    }
+
+    const assetsDirectory = resolve(dirname(documentPath), '.markdown-studio', 'assets')
+    const requestedPath = resolve(dirname(documentPath), relativePath)
+    const pathFromAssets = relative(assetsDirectory, requestedPath)
+
+    if (!pathFromAssets || pathFromAssets.startsWith('..') || isAbsolute(pathFromAssets)) {
+      return new Response('Asset path is outside the managed assets folder.', { status: 403 })
+    }
+
+    const extension = extname(requestedPath).toLowerCase()
+    const contentType = CONTENT_TYPES[extension]
+    if (!contentType) return new Response('Unsupported image format.', { status: 415 })
+
+    const [realAssetsDirectory, realRequestedPath] = await Promise.all([
+      realpath(assetsDirectory),
+      realpath(requestedPath),
+    ])
+    const realPathFromAssets = relative(realAssetsDirectory, realRequestedPath)
+
+    if (realPathFromAssets.startsWith('..') || isAbsolute(realPathFromAssets)) {
+      return new Response('Asset path is outside the managed assets folder.', { status: 403 })
+    }
+
+    return new Response(await readFile(realRequestedPath), {
+      headers: { 'content-type': contentType },
+    })
+  } catch {
+    return new Response('Asset not found.', { status: 404 })
+  }
+}

--- a/apps/desktop/electron/ipc/documents.ts
+++ b/apps/desktop/electron/ipc/documents.ts
@@ -15,12 +15,14 @@ import {
   EDITING_INSERT_TEXT_CHANNEL,
   EXPORTS_HTML_CHANNEL,
   EXPORTS_PDF_CHANNEL,
+  IMAGES_SAVE_CHANNEL,
   SHELL_OPEN_EXTERNAL_CHANNEL,
 } from '@markdown-studio/desktop-contract/channels'
 import {
   assertExportInput,
   assertExternalUrl,
   assertSaveAsInput,
+  assertSaveImageInput,
   assertSaveInput,
   assertWorkspaceDraft,
   assertWorkspaceDraftInput,
@@ -30,6 +32,8 @@ import {
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+
+import { saveImage } from './images'
 
 const HTML_FILTERS = [
   { extensions: ['html'], name: 'HTML Files' },
@@ -151,6 +155,7 @@ export function registerDesktopIpc(mainWindow: BrowserWindow): void {
   ipcMain.removeHandler(EDITING_INSERT_TEXT_CHANNEL)
   ipcMain.removeHandler(EXPORTS_HTML_CHANNEL)
   ipcMain.removeHandler(EXPORTS_PDF_CHANNEL)
+  ipcMain.removeHandler(IMAGES_SAVE_CHANNEL)
   ipcMain.removeHandler(SHELL_OPEN_EXTERNAL_CHANNEL)
 
   ipcMain.handle(DOCUMENTS_CLEAR_LAST_OPENED_CHANNEL, async () =>
@@ -174,6 +179,9 @@ export function registerDesktopIpc(mainWindow: BrowserWindow): void {
   })
   ipcMain.handle(EXPORTS_HTML_CHANNEL, async (_, payload) => exportHtml(mainWindow, payload))
   ipcMain.handle(EXPORTS_PDF_CHANNEL, async (_, payload) => exportPdf(mainWindow, payload))
+  ipcMain.handle(IMAGES_SAVE_CHANNEL, async (_, payload) =>
+    saveImage(assertSaveImageInput(payload)),
+  )
   ipcMain.handle(SHELL_OPEN_EXTERNAL_CHANNEL, (_, url) =>
     shell.openExternal(assertExternalUrl(url)),
   )

--- a/apps/desktop/electron/ipc/images.spec.ts
+++ b/apps/desktop/electron/ipc/images.spec.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { saveImage } from './images'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  )
+})
+
+describe('saveImage', () => {
+  it('saves an image in the Markdown Document assets folder', async () => {
+    const documentDirectory = await mkdtemp(join(tmpdir(), 'markdown-studio-images-'))
+    temporaryDirectories.push(documentDirectory)
+    const imageData = new Uint8Array([137, 80, 78, 71])
+
+    const result = await saveImage({
+      data: imageData,
+      documentPath: join(documentDirectory, 'notes.md'),
+      filename: 'Diagram.png',
+    })
+
+    expect(result).toEqual({
+      filename: 'diagram.png',
+      relativePath: './.markdown-studio/assets/diagram.png',
+    })
+    await expect(
+      readFile(join(documentDirectory, '.markdown-studio', 'assets', 'diagram.png')),
+    ).resolves.toEqual(Buffer.from(imageData))
+  })
+
+  it('chooses a unique filename without replacing an existing image', async () => {
+    const documentDirectory = await mkdtemp(join(tmpdir(), 'markdown-studio-images-'))
+    temporaryDirectories.push(documentDirectory)
+    const input = {
+      data: new Uint8Array([1]),
+      documentPath: join(documentDirectory, 'notes.md'),
+      filename: 'Diagram.png',
+    }
+
+    await saveImage(input)
+    const result = await saveImage({ ...input, data: new Uint8Array([2]) })
+
+    expect(result).toEqual({
+      filename: 'diagram-1.png',
+      relativePath: './.markdown-studio/assets/diagram-1.png',
+    })
+    await expect(
+      readFile(join(documentDirectory, '.markdown-studio', 'assets', 'diagram.png')),
+    ).resolves.toEqual(Buffer.from([1]))
+    await expect(
+      readFile(join(documentDirectory, '.markdown-studio', 'assets', 'diagram-1.png')),
+    ).resolves.toEqual(Buffer.from([2]))
+  })
+})

--- a/apps/desktop/electron/ipc/images.ts
+++ b/apps/desktop/electron/ipc/images.ts
@@ -1,0 +1,44 @@
+import type {
+  DesktopSaveImageInput,
+  DesktopSaveImageResult,
+} from '@markdown-studio/desktop-contract/types'
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, extname, join } from 'node:path'
+
+const SUPPORTED_IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
+
+export async function saveImage(input: DesktopSaveImageInput): Promise<DesktopSaveImageResult> {
+  const extension = extname(input.filename).toLowerCase()
+  if (!SUPPORTED_IMAGE_EXTENSIONS.has(extension)) {
+    throw new Error('Unsupported image format.')
+  }
+
+  const basename = sanitizeFilename(input.filename.slice(0, -extension.length))
+  const assetsDirectory = join(dirname(input.documentPath), '.markdown-studio', 'assets')
+
+  await mkdir(assetsDirectory, { recursive: true })
+
+  for (let suffix = 0; ; suffix += 1) {
+    const filename = `${basename}${suffix === 0 ? '' : `-${suffix}`}${extension}`
+
+    try {
+      await writeFile(join(assetsDirectory, filename), input.data, { flag: 'wx' })
+      return {
+        filename,
+        relativePath: `./.markdown-studio/assets/${filename}`,
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+    }
+  }
+}
+
+function sanitizeFilename(filename: string): string {
+  return (
+    filename
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'image'
+  )
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,12 +1,26 @@
-import { app, BrowserWindow, Menu, shell } from 'electron'
+import { app, BrowserWindow, Menu, protocol, shell } from 'electron'
 import { fileURLToPath } from 'node:url'
 
+import { handleAssetRequest } from './asset-protocol'
 import { registerDesktopIpc } from './ipc/documents'
 import { registerInstallIpc } from './ipc/install-method'
 import { buildAppMenu } from './menu/appMenu'
 
+const ASSET_PROTOCOL = 'markdown-studio-asset'
 const preloadPath = fileURLToPath(new URL('../preload/preload.cjs', import.meta.url))
 const rendererHtmlPath = fileURLToPath(new URL('../renderer/index.html', import.meta.url))
+
+protocol.registerSchemesAsPrivileged([
+  {
+    privileges: {
+      corsEnabled: true,
+      secure: true,
+      standard: true,
+      supportFetchAPI: true,
+    },
+    scheme: ASSET_PROTOCOL,
+  },
+])
 
 app.setName('Markdown Studio')
 
@@ -93,6 +107,7 @@ async function openExternal(url: string): Promise<void> {
 }
 
 app.whenReady().then(async () => {
+  protocol.handle(ASSET_PROTOCOL, handleAssetRequest)
   await createMainWindow()
 
   app.on('activate', async () => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -13,6 +13,7 @@ import {
   EDITING_INSERT_TEXT_CHANNEL,
   EXPORTS_HTML_CHANNEL,
   EXPORTS_PDF_CHANNEL,
+  IMAGES_SAVE_CHANNEL,
   INSTALL_IS_HOMEBREW_CHANNEL,
   SHELL_OPEN_EXTERNAL_CHANNEL,
 } from '@markdown-studio/desktop-contract/channels'
@@ -53,6 +54,9 @@ function createDesktopApi(): DesktopApi {
     exports: {
       exportHtml: (input) => ipcRenderer.invoke(EXPORTS_HTML_CHANNEL, input),
       exportPdf: (input) => ipcRenderer.invoke(EXPORTS_PDF_CHANNEL, input),
+    },
+    images: {
+      save: (input) => ipcRenderer.invoke(IMAGES_SAVE_CHANNEL, input),
     },
     install: {
       isHomebrew: () => ipcRenderer.invoke(INSTALL_IS_HOMEBREW_CHANNEL),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   "main": "out/main/main.js",
   "scripts": {
     "build": "electron-vite build",
+    "test": "vitest run",
     "dev": "electron-vite dev --watch",
     "dist:mac": "pnpm build && electron-builder --mac --config.mac.identity=null --publish never",
     "preview": "electron-vite preview"
@@ -36,6 +37,7 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-plugin-vue-devtools": "catalog:",
+    "vitest": "catalog:",
     "vue-tsc": "catalog:"
   },
   "build": {

--- a/packages/app/src/composables/useDesktop.ts
+++ b/packages/app/src/composables/useDesktop.ts
@@ -25,6 +25,11 @@ const fallbackDesktopApi: DesktopApi = {
     exportHtml: async () => null,
     exportPdf: async () => null,
   },
+  images: {
+    save: async () => {
+      throw new Error('Image saving is unavailable in the web runtime.')
+    },
+  },
   install: {
     isHomebrew: async () => false,
   },

--- a/packages/app/src/features/markdown/components/EditorPane.vue
+++ b/packages/app/src/features/markdown/components/EditorPane.vue
@@ -24,11 +24,13 @@ import MatchOverlay from './MatchOverlay.vue'
 
 interface Props {
   content: string
+  documentPath?: null | string
   findState?: EditorWorkspaceFindState
   lineCount: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  documentPath: null,
   findState: () => ({
     activeMatchIndex: -1,
     isOpen: false,
@@ -49,6 +51,7 @@ const emit = defineEmits<{
 
 const editorRef = useTemplateRef<HTMLTextAreaElement>('editor')
 const findReplaceBarRef = useTemplateRef<InstanceType<typeof FindReplaceBar>>('findReplaceBar')
+const isImageDragging = shallowRef(false)
 const scrollbarWidth = shallowRef(0)
 const scrollTop = shallowRef(0)
 let resizeObserver: null | ResizeObserver = null
@@ -114,6 +117,32 @@ function getScrollState(): EditorScrollPayload | null {
   }
 }
 
+function handleDragLeave(): void {
+  isImageDragging.value = false
+}
+
+function handleDragOver(event: DragEvent): void {
+  const dataTransfer = event.dataTransfer
+  if (!dataTransfer) {
+    isImageDragging.value = false
+    return
+  }
+
+  const hasSupportedImageItem = Array.from(dataTransfer.items ?? []).some(
+    (item) => item.kind === 'file' && /image\/(gif|jpeg|png|svg\+xml|webp)/i.test(item.type),
+  )
+  isImageDragging.value =
+    hasSupportedImageItem || Array.from(dataTransfer.files ?? []).some(isSupportedImage)
+}
+
+async function handleDrop(event: DragEvent): Promise<void> {
+  isImageDragging.value = false
+  const file = [...(event.dataTransfer?.files ?? [])].find(isSupportedImage)
+  if (!file) return
+
+  await insertImage(file)
+}
+
 function handleKeydown(event: KeyboardEvent): void {
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
     event.preventDefault()
@@ -145,6 +174,24 @@ function handleKeydown(event: KeyboardEvent): void {
   }
 }
 
+async function insertImage(file: File): Promise<void> {
+  const editor = editorRef.value
+  const browserWindow = window as AppWindow
+  const images = browserWindow.desktop?.images
+  if (!editor || !props.documentPath || !browserWindow.desktop?.isDesktop || !images) return
+
+  const start = editor.selectionStart
+  const end = editor.selectionEnd
+  const result = await images.save({
+    data: new Uint8Array(await file.arrayBuffer()),
+    documentPath: props.documentPath,
+    filename: file.name,
+  })
+
+  editor.setSelectionRange(start, end)
+  await insertText(`![${result.filename}](${result.relativePath})`)
+}
+
 async function insertText(text: string): Promise<void> {
   const editor = editorRef.value
   if (!editor) return
@@ -162,6 +209,10 @@ async function insertText(text: string): Promise<void> {
   }
 
   insertTextAtSelection(editor, text, start, end)
+}
+
+function isSupportedImage(file: File): boolean {
+  return /\.(gif|jpe?g|png|svg|webp)$/i.test(file.name)
 }
 
 async function replaceAllContent(nextContent: string): Promise<void> {
@@ -234,6 +285,7 @@ defineExpose({
   focusAtOffset,
   focusFindQuery,
   getScrollState,
+  insertImage,
   insertText,
   replaceAllContent,
   replaceRange,
@@ -269,7 +321,13 @@ watch(
 </script>
 
 <template>
-  <div class="editor-pane">
+  <div
+    class="editor-pane"
+    :class="{ 'editor-pane--image-dragging': isImageDragging }"
+    @dragleave="handleDragLeave"
+    @dragover.prevent="handleDragOver"
+    @drop.prevent="handleDrop"
+  >
     <div class="pane-header">
       <span class="pane-label">Markdown</span>
       <span class="line-count">{{ lineCount }} line{{ lineCount !== 1 ? 's' : '' }}</span>
@@ -295,6 +353,12 @@ watch(
     />
 
     <div class="editor-body">
+      <div v-show="isImageDragging" class="image-drop-overlay" aria-hidden="true">
+        <div class="image-drop-message">
+          <span class="image-drop-label">Drop image to add it</span>
+          <span class="image-drop-hint">PNG, JPG, GIF, WebP, or SVG</span>
+        </div>
+      </div>
       <MatchOverlay
         :active-match-index="findState.activeMatchIndex"
         :content="content"
@@ -329,6 +393,45 @@ watch(
   flex: 1;
   min-height: 0;
   background: var(--surface);
+}
+
+.image-drop-overlay {
+  position: absolute;
+  inset: 12px;
+  z-index: 3;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  border: 2px dashed var(--accent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 16%, var(--surface));
+  box-shadow:
+    0 0 0 12px color-mix(in srgb, var(--surface) 82%, transparent),
+    0 16px 40px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.image-drop-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 22px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-radius: 10px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--text) 12%, transparent);
+}
+
+.image-drop-label {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.image-drop-hint {
+  color: var(--text-muted);
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
 }
 
 .pane-header {

--- a/packages/app/src/features/markdown/components/PreviewPane.vue
+++ b/packages/app/src/features/markdown/components/PreviewPane.vue
@@ -9,13 +9,16 @@ import type { MarkdownSourceMapEntry, Theme } from '../types'
 import { sanitizeRenderedMarkdownPreviewHtml } from '../rendered-document'
 
 interface Props {
+  documentPath?: null | string
   html: string
   sourceMap: MarkdownSourceMapEntry[]
   theme: Theme
   wordCount: number
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  documentPath: null,
+})
 const desktop = useDesktop()
 
 const emit = defineEmits<{
@@ -29,7 +32,11 @@ const previewScrollRef = useTemplateRef<HTMLDivElement>('previewScroll')
 const renderKey = ref(0)
 
 const sanitizedHtml = computed(() =>
-  sanitizeRenderedMarkdownPreviewHtml(props.html, desktop.value.isDesktop ? 'desktop' : 'web'),
+  sanitizeRenderedMarkdownPreviewHtml(
+    props.html,
+    desktop.value.isDesktop ? 'desktop' : 'web',
+    props.documentPath,
+  ),
 )
 
 function getAnchorTop(element: HTMLElement, scrollContainer: HTMLDivElement): number {

--- a/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/EditorPane.spec.ts
@@ -145,6 +145,121 @@ describe('EditorPane', () => {
     expect(replaceButtons.every((button) => button.attributes('disabled') !== undefined)).toBe(true)
   })
 
+  it('highlights the editor while an image is dragged over it', async () => {
+    const wrapper = mountEditorPane({ documentPath: '/tmp/notes.md' })
+    const pane = wrapper.get('.editor-pane')
+    await pane.trigger('dragover', {
+      dataTransfer: {
+        files: [],
+        items: [{ kind: 'file', type: 'image/png' }],
+      },
+    })
+    expect(pane.classes()).toContain('editor-pane--image-dragging')
+    expect(wrapper.get('.image-drop-overlay').isVisible()).toBe(true)
+    expect(wrapper.get('.image-drop-label').text()).toBe('Drop image to add it')
+
+    await pane.trigger('dragleave')
+    expect(pane.classes()).not.toContain('editor-pane--image-dragging')
+    expect(wrapper.get('.image-drop-overlay').isVisible()).toBe(false)
+  })
+
+  it('does not highlight unsupported files', async () => {
+    const wrapper = mountEditorPane({ documentPath: '/tmp/notes.md' })
+    const pane = wrapper.get('.editor-pane')
+    const textFile = new File(['notes'], 'notes.txt', { type: 'text/plain' })
+
+    await pane.trigger('dragover', { dataTransfer: { files: [textFile] } })
+
+    expect(pane.classes()).not.toContain('editor-pane--image-dragging')
+  })
+
+  it('saves a dropped image and inserts Markdown at the cursor on desktop', async () => {
+    const insertText = vi.fn(async (value: string) => {
+      const textarea = document.activeElement as HTMLTextAreaElement
+      textarea.setRangeText(value, textarea.selectionStart, textarea.selectionEnd, 'end')
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const saveImage = vi.fn(async () => ({
+      filename: 'diagram.png',
+      relativePath: './.markdown-studio/assets/diagram.png',
+    }))
+    appWindow.desktop = {
+      commands: { onAppCommand: () => () => undefined },
+      documents: {
+        clearLastOpened: async () => undefined,
+        clearWorkspaceDraft: async () => undefined,
+        open: async () => null,
+        restoreLastOpened: async () => null,
+        restoreWorkspaceDraft: async () => null,
+        save: async () => null,
+        saveAs: async () => null,
+        saveWorkspaceDraft: async () => undefined,
+      },
+      editing: { insertText },
+      exports: { exportHtml: async () => null, exportPdf: async () => null },
+      images: { save: saveImage },
+      install: { isHomebrew: async () => false },
+      isDesktop: true,
+      shell: { openExternal: async () => undefined },
+    }
+
+    const wrapper = mountEditorPane({
+      content: 'before after',
+      documentPath: '/tmp/notes.md',
+      lineCount: 1,
+    })
+    const textarea = wrapper.get('textarea').element as HTMLTextAreaElement
+    textarea.value = 'before after'
+    textarea.setSelectionRange(6, 6)
+    const file = new File([new Uint8Array([1, 2, 3])], 'Diagram.png', { type: 'image/png' })
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: async () => new Uint8Array([1, 2, 3]).buffer,
+    })
+
+    await wrapper.get('.editor-pane').trigger('drop', {
+      dataTransfer: { files: [file] },
+    })
+
+    expect(saveImage).toHaveBeenCalledWith({
+      data: new Uint8Array([1, 2, 3]),
+      documentPath: '/tmp/notes.md',
+      filename: 'Diagram.png',
+    })
+    expect(insertText).toHaveBeenCalledWith('![diagram.png](./.markdown-studio/assets/diagram.png)')
+    expect(textarea.value).toBe('before![diagram.png](./.markdown-studio/assets/diagram.png) after')
+  })
+
+  it('ignores image drops for an unsaved Markdown Document', async () => {
+    const saveImage = vi.fn()
+    appWindow.desktop = {
+      commands: { onAppCommand: () => () => undefined },
+      documents: {
+        clearLastOpened: async () => undefined,
+        clearWorkspaceDraft: async () => undefined,
+        open: async () => null,
+        restoreLastOpened: async () => null,
+        restoreWorkspaceDraft: async () => null,
+        save: async () => null,
+        saveAs: async () => null,
+        saveWorkspaceDraft: async () => undefined,
+      },
+      editing: { insertText: vi.fn() },
+      exports: { exportHtml: async () => null, exportPdf: async () => null },
+      images: { save: saveImage },
+      install: { isHomebrew: async () => false },
+      isDesktop: true,
+      shell: { openExternal: async () => undefined },
+    }
+    const wrapper = mountEditorPane({ documentPath: null })
+    const image = new File(['image'], 'diagram.png', { type: 'image/png' })
+
+    await wrapper.get('.editor-pane').trigger('drop', {
+      dataTransfer: { files: [image] },
+    })
+
+    expect(saveImage).not.toHaveBeenCalled()
+  })
+
   it('prefers the Electron native edit path on desktop', async () => {
     const insertText = vi.fn(async (value: string) => {
       const textarea = document.activeElement as HTMLTextAreaElement

--- a/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
+++ b/packages/app/src/features/markdown/components/__tests__/PreviewPane.spec.ts
@@ -127,6 +127,43 @@ describe('PreviewPane', () => {
     expect(sourceElement.attributes('data-source-end')).toBe('5')
   })
 
+  it('resolves managed document images through the desktop asset protocol', async () => {
+    appWindow.desktop = {
+      commands: { onAppCommand: () => () => undefined },
+      documents: {
+        clearLastOpened: async () => undefined,
+        clearWorkspaceDraft: async () => undefined,
+        open: async () => null,
+        restoreLastOpened: async () => null,
+        restoreWorkspaceDraft: async () => null,
+        save: async () => null,
+        saveAs: async () => null,
+        saveWorkspaceDraft: async () => undefined,
+      },
+      editing: { insertText: async () => undefined },
+      exports: { exportHtml: async () => null, exportPdf: async () => null },
+      install: { isHomebrew: async () => false },
+      isDesktop: true,
+      shell: { openExternal: async () => undefined },
+    }
+
+    const wrapper = mount(PreviewPane, {
+      props: {
+        documentPath: '/tmp/notes.md',
+        html: '<p><img alt="diagram" src="./.markdown-studio/assets/diagram.png"></p>',
+        sourceMap: [],
+        theme: 'light',
+        wordCount: 1,
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.get('img').attributes('src')).toBe(
+      'markdown-studio-asset://local/?documentPath=%2Ftmp%2Fnotes.md&relativePath=.%2F.markdown-studio%2Fassets%2Fdiagram.png',
+    )
+  })
+
   it('strips iframe embeds in desktop mode and opens safe external links via the shell bridge', async () => {
     const openExternal = vi.fn(async () => undefined)
     appWindow.desktop = {

--- a/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
+++ b/packages/app/src/features/markdown/composables/__tests__/useDocumentExport.spec.ts
@@ -172,6 +172,7 @@ describe('useDocumentExport', () => {
   })
 
   it('delegates exports to the desktop bridge when available', async () => {
+    content.value = '# Export\n\n![diagram](./.markdown-studio/assets/diagram.png)'
     const exportHtml = vi.fn(async () => ({ path: '/tmp/export.html' }))
     const exportPdf = vi.fn(async () => ({ path: '/tmp/export.pdf' }))
     appWindow.desktop = {
@@ -219,13 +220,15 @@ describe('useDocumentExport', () => {
 
     expect(exportHtml).toHaveBeenCalledWith(
       expect.objectContaining({
-        documentHtml: expect.stringContaining('<!DOCTYPE html>'),
+        documentHtml: expect.stringContaining('src="./.markdown-studio/assets/diagram.png"'),
         suggestedPath: 'export-notes.html',
       }),
     )
     expect(exportPdf).toHaveBeenCalledWith(
       expect.objectContaining({
-        documentHtml: expect.stringContaining('<!DOCTYPE html>'),
+        documentHtml: expect.stringContaining(
+          'src="markdown-studio-asset://local/?documentPath=%2Ftmp%2Fexport-notes.md&amp;relativePath=.%2F.markdown-studio%2Fassets%2Fdiagram.png"',
+        ),
         suggestedPath: 'export-notes.pdf',
       }),
     )

--- a/packages/app/src/features/markdown/composables/useDocumentExport.ts
+++ b/packages/app/src/features/markdown/composables/useDocumentExport.ts
@@ -11,6 +11,7 @@ import {
   getDefaultTitle,
   getSuggestedFileName,
   renderExport,
+  resolveDesktopAssetUrls,
 } from '../rendered-document'
 
 interface UseDocumentExportOptions {
@@ -166,8 +167,12 @@ export function useDocumentExport(options: UseDocumentExportOptions): UseDocumen
     const suggestedPath = getSuggestedFileName(getDocumentPath(), 'pdf')
 
     if (desktop.value.isDesktop) {
+      const pdfDocumentHtml = options.currentPath.value
+        ? resolveDesktopAssetUrls(documentHtml, options.currentPath.value)
+        : documentHtml
+
       await desktop.value.exports.exportPdf({
-        documentHtml,
+        documentHtml: pdfDocumentHtml,
         documentTitle: rendered.title,
         suggestedPath,
       })

--- a/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
+++ b/packages/app/src/features/markdown/composables/useEditorWorkspaceController.ts
@@ -640,6 +640,7 @@ export function useEditorWorkspaceController(): EditorWorkspaceController {
       canOpenDocuments,
       canSaveDocuments,
       content,
+      currentPath,
       displayName,
       homebrewUpgradeCommand,
       isCopied,

--- a/packages/app/src/features/markdown/rendered-document/index.ts
+++ b/packages/app/src/features/markdown/rendered-document/index.ts
@@ -148,16 +148,41 @@ export function renderPreview(input: RenderedMarkdownPreviewInput): RenderedMark
   }
 }
 
+export function resolveDesktopAssetUrls(html: string, documentPath: string): string {
+  const isFullDocument = /^\s*<!doctype html>/i.test(html)
+  const parser = new DOMParser()
+  const documentNode = parser.parseFromString(html, 'text/html')
+
+  for (const image of documentNode.querySelectorAll<HTMLImageElement>('img[src]')) {
+    const relativePath = image.getAttribute('src')
+    if (!relativePath?.startsWith('./.markdown-studio/assets/')) continue
+
+    const assetUrl = new URL('markdown-studio-asset://local/')
+    assetUrl.searchParams.set('documentPath', documentPath)
+    assetUrl.searchParams.set('relativePath', relativePath)
+    image.setAttribute('src', assetUrl.toString())
+  }
+
+  return isFullDocument
+    ? `<!doctype html>\n${documentNode.documentElement.outerHTML}`
+    : documentNode.body.innerHTML
+}
+
 export function sanitizeRenderedMarkdownPreviewHtml(
   html: string,
   runtime: 'desktop' | 'web',
+  documentPath?: null | string,
 ): string {
-  return DOMPurify.sanitize(html, {
+  const sanitizedHtml = DOMPurify.sanitize(html, {
     ADD_ATTR: ['data-source-end', 'data-source-id', 'data-source-start', 'id'],
     FORBID_ATTR:
       runtime === 'desktop' ? ['allow', 'allowfullscreen', 'frameborder', 'scrolling'] : [],
     FORBID_TAGS: runtime === 'desktop' ? ['iframe'] : [],
   })
+
+  if (runtime !== 'desktop' || !documentPath) return sanitizedHtml
+
+  return resolveDesktopAssetUrls(sanitizedHtml, documentPath)
 }
 
 function createMermaidId(index: number): string {

--- a/packages/app/src/features/markdown/types/workspace.ts
+++ b/packages/app/src/features/markdown/types/workspace.ts
@@ -143,6 +143,7 @@ export interface EditorWorkspaceState {
   canOpenDocuments: Readonly<Ref<boolean>>
   canSaveDocuments: Readonly<Ref<boolean>>
   content: Readonly<Ref<string>>
+  currentPath: Readonly<Ref<null | string>>
   displayName: Readonly<Ref<string>>
   homebrewUpgradeCommand: Readonly<ComputedRef<string>>
   isCopied: Readonly<Ref<boolean>>

--- a/packages/app/src/views/MarkdownStudioView.vue
+++ b/packages/app/src/views/MarkdownStudioView.vue
@@ -92,6 +92,7 @@ const {
   canOpenDocuments,
   canSaveDocuments,
   content,
+  currentPath,
   displayName,
   homebrewUpgradeCommand,
   isCopied,
@@ -312,6 +313,7 @@ function handleTableInsertionConfirm(): void {
       <EditorPane
         ref="editorPane"
         :content="content"
+        :document-path="currentPath"
         :find-state="workspace.find.state.value"
         :line-count="stats.lines"
         @find-action="handleFindAction"
@@ -320,6 +322,7 @@ function handleTableInsertionConfirm(): void {
       />
       <PreviewPane
         ref="previewPane"
+        :document-path="currentPath"
         :html="renderedHtml"
         :source-map="sourceMap"
         :theme="theme"

--- a/packages/desktop-contract/__tests__/validation.spec.ts
+++ b/packages/desktop-contract/__tests__/validation.spec.ts
@@ -6,6 +6,7 @@ import {
   assertExportInput,
   assertExternalUrl,
   assertSaveAsInput,
+  assertSaveImageInput,
   assertSaveInput,
   assertWorkspaceDraft,
   assertWorkspaceDraftInput,
@@ -32,6 +33,17 @@ describe('desktop validation', () => {
     })
     expect(getDefaultMarkdownPath('notes')).toBe('notes.md')
     expect(getDefaultMarkdownPath()).toBe('Untitled.md')
+  })
+
+  it('accepts supported image payloads and rejects non-image filenames', () => {
+    const data = new Uint8Array([1, 2, 3])
+
+    expect(
+      assertSaveImageInput({ data, documentPath: '/tmp/notes.md', filename: 'Diagram.WEBP' }),
+    ).toEqual({ data, documentPath: '/tmp/notes.md', filename: 'Diagram.WEBP' })
+    expect(() =>
+      assertSaveImageInput({ data, documentPath: '/tmp/notes.md', filename: 'notes.txt' }),
+    ).toThrow('Unsupported image format')
   })
 
   it('normalizes export payloads and paths', () => {

--- a/packages/desktop-contract/src/channels.ts
+++ b/packages/desktop-contract/src/channels.ts
@@ -11,4 +11,5 @@ export const DOCUMENTS_SAVE_WORKSPACE_DRAFT_CHANNEL = 'documents:saveWorkspaceDr
 export const EDITING_INSERT_TEXT_CHANNEL = 'editing:insertText'
 export const EXPORTS_HTML_CHANNEL = 'exports:html'
 export const EXPORTS_PDF_CHANNEL = 'exports:pdf'
+export const IMAGES_SAVE_CHANNEL = 'images:save'
 export const SHELL_OPEN_EXTERNAL_CHANNEL = 'shell:openExternal'

--- a/packages/desktop-contract/src/types.ts
+++ b/packages/desktop-contract/src/types.ts
@@ -13,6 +13,7 @@ export interface DesktopApi {
   documents: DesktopDocumentsApi
   editing: DesktopEditingApi
   exports: DesktopExportsApi
+  images?: DesktopImagesApi
   install: DesktopInstallApi
   isDesktop: boolean
   shell: DesktopShellApi
@@ -53,6 +54,10 @@ export interface DesktopExportsApi {
   exportPdf: (input: DesktopExportInput) => Promise<{ path: string } | null>
 }
 
+export interface DesktopImagesApi {
+  save: (input: DesktopSaveImageInput) => Promise<DesktopSaveImageResult>
+}
+
 export interface DesktopInstallApi {
   isHomebrew: () => Promise<boolean>
 }
@@ -60,6 +65,17 @@ export interface DesktopInstallApi {
 export interface DesktopSaveAsInput {
   content: string
   suggestedPath?: null | string
+}
+
+export interface DesktopSaveImageInput {
+  data: Uint8Array
+  documentPath: string
+  filename: string
+}
+
+export interface DesktopSaveImageResult {
+  filename: string
+  relativePath: string
 }
 
 export interface DesktopSaveInput {

--- a/packages/desktop-contract/src/validation.ts
+++ b/packages/desktop-contract/src/validation.ts
@@ -1,6 +1,7 @@
 import type {
   DesktopExportInput,
   DesktopSaveAsInput,
+  DesktopSaveImageInput,
   DesktopSaveInput,
   DesktopWorkspaceDraft,
   DesktopWorkspaceDraftInput,
@@ -43,6 +44,25 @@ export function assertSaveAsInput(value: unknown): DesktopSaveAsInput {
       input.suggestedPath === undefined || input.suggestedPath === null
         ? null
         : assertNonEmptyPath(input.suggestedPath),
+  }
+}
+
+export function assertSaveImageInput(value: unknown): DesktopSaveImageInput {
+  assertObject(value, 'Save image payload must be an object.')
+  const input = value as Record<string, unknown>
+
+  if (!(input.data instanceof Uint8Array)) {
+    throw new TypeError('Image data must be binary.')
+  }
+
+  if (typeof input.filename !== 'string' || !/\.(gif|jpe?g|png|svg|webp)$/i.test(input.filename)) {
+    throw new Error('Unsupported image format.')
+  }
+
+  return {
+    data: input.data,
+    documentPath: assertNonEmptyPath(input.documentPath),
+    filename: input.filename,
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       vite-plugin-vue-devtools:
         specifier: 'catalog:'
         version: 8.1.4(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@24.13.2)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@8.1.0(@types/node@24.13.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.5(typescript@6.0.3)
@@ -10453,7 +10456,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -11218,11 +11221,11 @@ snapshots:
 
   node-abi@4.31.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-gyp@12.4.0:
     dependencies:
@@ -11231,7 +11234,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.17
       tinyglobby: 0.2.17
       undici: 6.27.0


### PR DESCRIPTION
## Summary

Add desktop image drag and drop for saved Markdown Documents, storing images in a managed `.markdown-studio/assets` folder and inserting portable relative Markdown paths. Resolve managed images securely in Live Preview and PDF exports across development and packaged desktop builds.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Workflow
- [x] Test

## Screenshots

<!-- Add screenshots or recordings showing the before/after if applicable -->

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

## Test Procedure

<!-- How was this tested? What should reviewers look for? -->

- [x] Unit tests pass: `pnpm test:unit`
- [ ] E2E tests pass: `pnpm test:e2e` (if applicable)
- [x] Manual testing notes: Verified image drag and drop, Live Preview rendering, HTML export, and PDF export in the desktop Runtime. Verified the production desktop build with `pnpm build:desktop`.

## Related Issue

<!-- Link to related GitHub issue (e.g., "Fixes #123", "Closes #456") -->

Closes #85

## Pre-flight Checklist

- [x] Tests added/updated for the changed functionality
- [x] Lint and type-check pass: `pnpm lint && pnpm type-check`
- [x] No unintended changes to other files
- [ ] UI changes have screenshots (if applicable)
